### PR TITLE
make composer generate archives containing assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,10 +133,12 @@
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",
         "symfony-tests-dir": "tests",
-        "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
         },
         "branch-alias": null
+    },
+    "archive": {
+        "exclude": ["!/web/build", "!/web/bundles"]
     }
 }


### PR DESCRIPTION
- add `archive.exclude` to _include_ assets generated with `composer install` and `composer encore`.
- remove `"symfony-assets-install": "relative"` as this will create symlinks which seem to be ignored when creating tar balls with `composer archive`.