### PR TITLE
Log the same sari request ID in web and app requests

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,6 +68,7 @@ surfnet_stepup:
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
+    exception_controller: SurfnetStepupBundle:Exception:show
 
 app:
     general:

--- a/src/AppBundle/Controller/AuthenticationController.php
+++ b/src/AppBundle/Controller/AuthenticationController.php
@@ -27,6 +27,7 @@ use AppBundle\Tiqr\TiqrUserRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Surfnet\GsspBundle\Service\AuthenticationService;
+use Surfnet\GsspBundle\Service\StateHandlerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,15 +43,18 @@ class AuthenticationController extends Controller
     private $logger;
     private $authenticationRateLimitService;
     private $userRepository;
+    private $stateHandler;
 
     public function __construct(
         AuthenticationService $authenticationService,
+        StateHandlerInterface $stateHandler,
         TiqrServiceInterface $tiqrService,
         TiqrUserRepositoryInterface $userRepository,
         AuthenticationRateLimitServiceInterface $authenticationRateLimitService,
         LoggerInterface $logger
     ) {
         $this->authenticationService = $authenticationService;
+        $this->stateHandler = $stateHandler;
         $this->tiqrService = $tiqrService;
         $this->logger = $logger;
         $this->authenticationRateLimitService = $authenticationRateLimitService;
@@ -129,7 +133,10 @@ class AuthenticationController extends Controller
         // Start authentication process.
         try {
             $logger->info('Start authentication');
-            $this->tiqrService->startAuthentication($nameId);
+            $this->tiqrService->startAuthentication(
+                $nameId,
+                $this->stateHandler->getRequestId()
+            );
         } catch (\Exception $e) {
             $logger->error(sprintf(
                 'Failed to start authentication "%s"',

--- a/src/AppBundle/Controller/RegistrationController.php
+++ b/src/AppBundle/Controller/RegistrationController.php
@@ -21,6 +21,7 @@ use AppBundle\Tiqr\TiqrServiceInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Psr\Log\LoggerInterface;
 use Surfnet\GsspBundle\Service\RegistrationService;
+use Surfnet\GsspBundle\Service\StateHandlerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,13 +31,16 @@ class RegistrationController extends Controller
     private $registrationService;
     private $tiqrService;
     private $logger;
+    private $stateHandler;
 
     public function __construct(
         RegistrationService $registrationService,
+        StateHandlerInterface $stateHandler,
         TiqrServiceInterface $tiqrService,
         LoggerInterface $logger
     ) {
         $this->registrationService = $registrationService;
+        $this->stateHandler = $stateHandler;
         $this->tiqrService = $tiqrService;
         $this->logger = $logger;
     }
@@ -115,7 +119,9 @@ class RegistrationController extends Controller
             return new Response('No registration required', Response::HTTP_BAD_REQUEST);
         }
         $this->logger->info('Generating enrollment key');
-        $key = $this->tiqrService->generateEnrollmentKey();
+        $key = $this->tiqrService->generateEnrollmentKey(
+            $this->stateHandler->getRequestId()
+        );
         $metadataURL = $request->getUriForPath(sprintf('/tiqr.php?key=%s', urlencode($key)));
 
         $this->logger->info('Returning registration QR response');

--- a/src/AppBundle/Features/Context/TiqrContext.php
+++ b/src/AppBundle/Features/Context/TiqrContext.php
@@ -331,7 +331,7 @@ class TiqrContext implements Context, KernelAwareContext
         $img = $page->find('css', 'div.qr > img');
         $src = $img->getAttribute('src');
 
-        $qrcode = new \QrReader($this->getFileContentsInsucure($src), \QrReader::SOURCE_TYPE_BLOB);
+        $qrcode = new \QrReader($this->getFileContentsInsecure($src), \QrReader::SOURCE_TYPE_BLOB);
         $content = $qrcode->text();
         Assertion::startsWith($content, 'tiqrenroll://');
         Assertion::eq(preg_match('/^tiqrenroll:\/\/(?P<url>.*)/', $content, $matches), 1);
@@ -354,7 +354,7 @@ class TiqrContext implements Context, KernelAwareContext
         $img = $page->find('css', 'div.qr > img');
         $src = $img->getAttribute('src');
 
-        $qrcode = new \QrReader($this->getFileContentsInsucure($src), \QrReader::SOURCE_TYPE_BLOB);
+        $qrcode = new \QrReader($this->getFileContentsInsecure($src), \QrReader::SOURCE_TYPE_BLOB);
         $content = $qrcode->text();
         Assertion::startsWith($content, 'tiqrauth://');
         Assertion::eq(preg_match('/^tiqrauth:\/\/(?P<url>.*)/', $content, $matches), 1);
@@ -432,7 +432,7 @@ class TiqrContext implements Context, KernelAwareContext
      * @return string
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function getFileContentsInsucure($src)
+    private function getFileContentsInsecure($src)
     {
         $session = $this->minkContext->getMink()->getSession();
         $driver = $session->getDriver();

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -19,6 +19,7 @@ services:
         public: false
         bind:
             $logger: '@surfnet_gssp.logger'
+            $stateHandler: '@surfnet_gssp.state_handler.service'
 
     # makes classes in src/AppBundle available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/AppBundle/Tiqr/TiqrFactory.php
+++ b/src/AppBundle/Tiqr/TiqrFactory.php
@@ -22,6 +22,7 @@ use AppBundle\Tiqr\Legacy\TiqrUserRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Tiqr_Service;
+use Tiqr_StateStorage;
 use Tiqr_UserStorage;
 
 class TiqrFactory
@@ -45,7 +46,20 @@ class TiqrFactory
     {
         $this->loadDependencies();
         $options = $this->configuration->getTiqrOptions();
-        return new TiqrService(new Tiqr_Service($options), $this->session);
+
+        $storageType = "file";
+        $storageOptions = array();
+
+        if (isset($options["statestorage"])) {
+            $storageType = $options["statestorage"]["type"];
+            $storageOptions = $options["statestorage"];
+        }
+
+        return new TiqrService(
+            new Tiqr_Service($options),
+            Tiqr_StateStorage::getStorage($storageType, $storageOptions),
+            $this->session
+        );
     }
 
     public function createUserRepository()

--- a/src/AppBundle/Tiqr/TiqrServiceInterface.php
+++ b/src/AppBundle/Tiqr/TiqrServiceInterface.php
@@ -51,9 +51,11 @@ interface TiqrServiceInterface
     /**
      * Starts and generates an enrollment key.
      *
+     * @param string $sari
+     *
      * @return string
      */
-    public function generateEnrollmentKey();
+    public function generateEnrollmentKey($sari);
 
     /**
      * Retrieve the metadata for an enrollment session.
@@ -122,10 +124,11 @@ interface TiqrServiceInterface
      * same device as where the application is installed
      *
      * @param string $nameId
+     * @param string $sari
      *
      * @return string
      */
-    public function startAuthentication($nameId);
+    public function startAuthentication($nameId, $sari);
 
     /**
      * @return boolean
@@ -188,4 +191,12 @@ interface TiqrServiceInterface
      * @return string
      */
     public function sendNotification($notificationType, $notificationAddress);
+
+    /**
+     * @param string $identifier Enrollment key or session key
+     * @param string $sari
+     *
+     * @return string
+     */
+    public function getSariForSessionIdentifier($identifier);
 }

--- a/src/DevTiqrClientBundle/Controller/QrLinkController.php
+++ b/src/DevTiqrClientBundle/Controller/QrLinkController.php
@@ -44,7 +44,7 @@ final class QrLinkController extends Controller
      */
     public function registrationQrAction(Request $request)
     {
-        $key = $this->tiqrService->generateEnrollmentKey();
+        $key = $this->tiqrService->generateEnrollmentKey('dev');
         $metadataURL = $request->getUriForPath(sprintf('/tiqr.php?key=%s', urlencode($key)));
         return $this->tiqrService->createRegistrationQRResponse($metadataURL);
     }
@@ -59,7 +59,7 @@ final class QrLinkController extends Controller
      */
     public function registrationLinkAction(Request $request)
     {
-        $key = $this->tiqrService->generateEnrollmentKey();
+        $key = $this->tiqrService->generateEnrollmentKey('dev');
         $metadataUrl = $request->getUriForPath(sprintf('/tiqr.php?key=%s', urlencode($key)));
         $metadataAppURL = 'tiqrenroll://'.$metadataUrl;
 
@@ -80,7 +80,7 @@ final class QrLinkController extends Controller
      */
     public function authenticationQrAction($nameId)
     {
-        $this->tiqrService->startAuthentication($nameId);
+        $this->tiqrService->startAuthentication($nameId, 'dev');
         return $this->tiqrService->createAuthenticationQRResponse();
     }
 
@@ -93,7 +93,7 @@ final class QrLinkController extends Controller
      */
     public function authenticationQrLinkAction($nameId)
     {
-        $this->tiqrService->startAuthentication($nameId);
+        $this->tiqrService->startAuthentication($nameId, 'dev');
         $challengeUrl = $this->tiqrService->authenticationUrl();
 
         // Simply return a html link, so they can click it and see the metadata result.


### PR DESCRIPTION
The sari used in log messages for requests from the app are now the
same as the one used in the corresponding web requests. This is
achieved by maintaining a mapping between the session
identifier (the tiqr enrollment key or tiqr session key) and the sari
request id.