### PR TITLE
Don't store the locale in a cookie

### DIFF
--- a/src/AppBundle/EventSubscriber/LocaleResponseListener.php
+++ b/src/AppBundle/EventSubscriber/LocaleResponseListener.php
@@ -19,7 +19,6 @@ namespace AppBundle\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -33,20 +32,15 @@ final class LocaleResponseListener implements EventSubscriberInterface
     const STEPUP_LOCALE_COOKIE = 'stepup_locale';
 
     private $translator;
-    private $requestStack;
 
-    public function __construct(
-        TranslatorInterface $translator,
-        RequestStack $requestStack
-    ) {
+    public function __construct(TranslatorInterface $translator)
+    {
         $this->translator = $translator;
-        $this->requestStack = $requestStack;
     }
 
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::RESPONSE => ['onKernelResponse'],
             KernelEvents::REQUEST => ['onKernelRequest'],
         ];
     }
@@ -62,37 +56,5 @@ final class LocaleResponseListener implements EventSubscriberInterface
         $local = $request->cookies->get(self::STEPUP_LOCALE_COOKIE, $request->getLocale());
         $request->setLocale($local);
         $this->translator->setLocale($local);
-    }
-
-    /**
-     * Preserves the current selected local as user cookie.
-     *
-     * @param FilterResponseEvent $event
-     */
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-        $request = $this->requestStack->getMasterRequest();
-        $response = $event->getResponse();
-        $cookie = new Cookie(
-            self::STEPUP_LOCALE_COOKIE,
-            $request->getLocale(),
-            0,
-            '/',
-            $this->getNakedDomain()
-        );
-        $response->headers->setCookie($cookie);
-    }
-
-    /**
-     * Return's the naked domain for the cookie variables so that is shared between the different sub-domains.
-     *
-     * @return string
-     */
-    private function getNakedDomain()
-    {
-        $masterRequest = $this->requestStack->getMasterRequest();
-        $host = $masterRequest->getHost();
-        $parts = explode('.', $host);
-        return implode('.', array_slice($parts, -2, 2));
     }
 }


### PR DESCRIPTION
The locale of tiqr was set in a cookie on a wrong domain (example.com
instead of stepup.example.com), because of this, changed language
settings in other components had no effect on subsequent visits to
tiqr.

Since tiqr no longer has a language switcher, there is no need to save
the locale. It now only reads the stepup_locale cookie and never
changes it.

See https://www.pivotaltracker.com/story/show/156334113