### PR TITLE
Fix error in handling permanently blocked users

### DIFF
--- a/src/AppBundle/Controller/AuthenticationController.php
+++ b/src/AppBundle/Controller/AuthenticationController.php
@@ -274,7 +274,7 @@ class AuthenticationController extends Controller
         }
         // Forward to the exception controller to prevent an error being logged.
         return $this->forward(
-            'AppBundle::Exception::show',
+            'AppBundle:Exception:show',
             [
                 'exception'=> $exception,
             ]

--- a/src/AppBundle/Controller/ExceptionController.php
+++ b/src/AppBundle/Controller/ExceptionController.php
@@ -43,7 +43,7 @@ final class ExceptionController extends BaseExceptionController
             $title = $translator->trans('login.error.account_temporarily_blocked.title');
             $description = $translator->trans('login.error.account_temporarily_blocked.description');
         } elseif ($exception instanceof UserPermanentlyBlockedException) {
-            $title = $translator->trans('login.error.account_permanently_blocked.description.title');
+            $title = $translator->trans('login.error.account_permanently_blocked.title');
             $description = $translator->trans('login.error.account_permanently_blocked.description');
         }
 


### PR DESCRIPTION
When a user has a permentent block, visiting /authentication triggered
a fatal error (class AppBundle not found) and there was a typo in the
error page title (.description.title -> .title).