### PR TITLE
Use less content in authentication QR screen

### DIFF
--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,7 @@ login:
         fail: Did you not receive a push notification? Click %link_start%here%link_end% and scan the QR code with your tiqr app.
     qr:
         message: Open the tiqr push notification on your phone and follow the instructions.
+        instruction: Scan this QR code with your tiqr app.
         manual:
             message: If your mobile phone is offline you need to
             no_push_notification: No push notification received? %link_start%Generate a QR-code%link_end% and scan it with your tiqr app.

--- a/src/AppBundle/Resources/translations/messages.nl.yml
+++ b/src/AppBundle/Resources/translations/messages.nl.yml
@@ -12,6 +12,7 @@ login:
       error: Er is iets fouts gebeurt
     qr:
         message: Open de de tiqr push notificatie op je telefoon en volg de instructies.
+        instruction: Scan deze QR code met je tiqr app.
         manual:
             message: Als je telefoon offline is moet je het
             no_push_notification: Geen push notificatie ontvangen? %link_start%Genereer de QR-code%link_end% en scan deze met je tiqr app.

--- a/src/AppBundle/Resources/views/default/authentication.html.twig
+++ b/src/AppBundle/Resources/views/default/authentication.html.twig
@@ -9,13 +9,13 @@
 {% endblock %}
 
 {% block body %}
-    {{ 'login.qr.message' | trans }}
-
     <div class="spinner-container">
-        <img class="img-rotate spinner" src="{{ asset('images/spinner.svg') }}">
-    </div>
+        {{ 'login.qr.message' | trans }}
 
-    {{ 'login.qr.manual.no_push_notification' | trans({ '%link_start%':'<a id="trigger-qr">', '%link_end%': '</a>' }) | raw }}
+        <img class="img-rotate spinner" src="{{ asset('images/spinner.svg') }}">
+
+        {{ 'login.qr.manual.no_push_notification' | trans({ '%link_start%':'<a id="trigger-qr">', '%link_end%': '</a>' }) | raw }}
+    </div>
 
     {% if otpError is defined %}
         <br/>
@@ -29,13 +29,13 @@
 
         </div>
     {% endif %}
-    <br/>
+
     <div id="qr" class="content-container qr">
+        {{ 'login.qr.instruction' | trans }}
+
         <img src="{{ url('app_identity_authentication_qr') }}">
 
-        <p>
-            {{ 'login.qr.manual.message' | trans }} <a onClick="jQuery('#otpform').slideToggle();">{{ 'login.qr.manual.here' | trans }}</a>.
-        </p>
+        {{ 'login.qr.manual.message' | trans }} <a onClick="jQuery('#otpform').slideToggle();">{{ 'login.qr.manual.here' | trans }}</a>.
     </div>
 
     <div id="otpform">
@@ -56,7 +56,7 @@
         jQuery('#trigger-qr').on('click', function(){
             jQuery('#qr').slideToggle();
             jQuery('#otpform').hide();
-            jQuery('.spinner').slideToggle();
+            jQuery('.spinner-container').slideToggle();
         });
 
         /**


### PR DESCRIPTION
The page was too heigh for embedding in Office365. Solved by simply
adding less content to the page when the QR is opened.

The height is now 40 pixels less than before this change!

See https://www.pivotaltracker.com/story/show/156334113/comments/190026529