### PR TITLE
Check the user agent of mobile app against configurable pattern

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -27,3 +27,7 @@ services:
         decorates: 'logger'
         arguments:
           - '@kernel'
+
+    AppBundle\Service\UserAgentMatcher:
+      arguments:
+        - '/^Behat UA$/'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -31,6 +31,13 @@ parameters:
         en_GB: "https://support.example.org/faq-strong-authentication"
         nl_NL: "https://support.example.org/faq-sterke-authenticatie"
 
+    # Mobile Tiqr apps identify themselves with a user agent
+    # header. If the user agent does not match below pattern during
+    # registration, registration will fail. The default pattern (^.*$)
+    # will effectively allow any Tiqr app. The pattern must adhere to
+    # PCRE as accepted by preg_match (http://php.net/preg_match).
+    mobile_app_user_agent_pattern: "/^.*$/"
+
     # Options for the tiqr library
     tiqr_library_options:
         general:

--- a/src/AppBundle/Controller/TiqrAppApiController.php
+++ b/src/AppBundle/Controller/TiqrAppApiController.php
@@ -17,6 +17,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Service\UserAgentMatcherInterface;
 use AppBundle\WithContextLogger;
 use AppBundle\Tiqr\AuthenticationRateLimitServiceInterface;
 use AppBundle\Tiqr\Exception\UserNotExistsException;
@@ -112,18 +113,19 @@ class TiqrAppApiController extends Controller
      * @Route("/tiqr/tiqr.php")
      * @Method({"POST"})
      *
+     * @param UserAgentMatcherInterface $userAgentMatcher
      * @param Request $request
      * @return Response
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    public function tiqr(Request $request)
+    public function tiqr(UserAgentMatcherInterface $userAgentMatcher, Request $request)
     {
         $operation = $request->get('operation');
         $notificationType = $request->get('notificationType');
         $notificationAddress = $request->get('notificationAddress');
         if ($operation === 'register') {
-            return $this->registerAction($request, $notificationType, $notificationAddress);
+            return $this->registerAction($userAgentMatcher, $request, $notificationType, $notificationAddress);
         }
         if ($operation === 'login') {
             return $this->loginAction($request, $notificationType, $notificationAddress);
@@ -133,6 +135,7 @@ class TiqrAppApiController extends Controller
     }
 
     /**
+     * @param UserAgentMatcherInterface $userAgentMatcher
      * @param Request $request
      * @param $notificationType
      * @param $notificationAddress
@@ -140,8 +143,22 @@ class TiqrAppApiController extends Controller
      * @return Response
      * @throws \InvalidArgumentException
      */
-    private function registerAction(Request $request, $notificationType, $notificationAddress)
-    {
+    private function registerAction(
+        UserAgentMatcherInterface $userAgentMatcher,
+        Request $request,
+        $notificationType,
+        $notificationAddress
+    ) {
+        if (!$userAgentMatcher->isOfficialTiqrMobileApp($request)) {
+            return new Response(
+                sprintf(
+                    'Received request from unsupported mobile app with user agent: "%s"',
+                    $request->headers->get('User-Agent')
+                ),
+                Response::HTTP_NOT_ACCEPTABLE
+            );
+        }
+
         $enrollmentSecret = $request->get('otp'); // enrollment secret relayed by tiqr app
         $secret = $request->get('secret');
 

--- a/src/AppBundle/Controller/TiqrAppApiController.php
+++ b/src/AppBundle/Controller/TiqrAppApiController.php
@@ -149,22 +149,23 @@ class TiqrAppApiController extends Controller
         $notificationType,
         $notificationAddress
     ) {
-        if (!$userAgentMatcher->isOfficialTiqrMobileApp($request)) {
-            return new Response(
-                sprintf(
-                    'Received request from unsupported mobile app with user agent: "%s"',
-                    $request->headers->get('User-Agent')
-                ),
-                Response::HTTP_NOT_ACCEPTABLE
-            );
-        }
-
         $enrollmentSecret = $request->get('otp'); // enrollment secret relayed by tiqr app
         $secret = $request->get('secret');
 
         $logger = WithContextLogger::from($this->logger, [
             'sari' => $this->tiqrService->getSariForSessionIdentifier($secret),
         ]);
+
+        if (!$userAgentMatcher->isOfficialTiqrMobileApp($request)) {
+            $message = sprintf(
+                'Received request from unsupported mobile app with user agent: "%s"',
+                $request->headers->get('User-Agent')
+            );
+
+            $logger->warning($message);
+
+            return new Response($message, Response::HTTP_NOT_ACCEPTABLE);
+        }
 
         $logger->info('Start validating enrollment secret');
 

--- a/src/AppBundle/Features/tiqrRegistration.feature
+++ b/src/AppBundle/Features/tiqrRegistration.feature
@@ -12,3 +12,9 @@ Feature: User
     Given the registration QR code is scanned
     When the user registers the service with notification type "APNS" address: "0000000000111111111122222222223333333333"
     Then we register with the same QR code it should not work anymore.
+
+  Scenario: Register a new service with unknown user agent
+    Given the registration QR code is scanned
+    And the mobile tiqr app identifies itself with the user agent "Bad UA"
+    When the user registers the service
+    Then tiqr errors with a message telling the wrong user agent was wrong

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -53,3 +53,7 @@ services:
       class: Surfnet\SamlBundle\SAML2\BridgeContainer
       arguments:
           - '@logger'
+
+    AppBundle\Service\UserAgentMatcher:
+      arguments:
+        - '%mobile_app_user_agent_pattern%'

--- a/src/AppBundle/Service/UserAgentMatcher.php
+++ b/src/AppBundle/Service/UserAgentMatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AppBundle\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class UserAgentMatcher implements UserAgentMatcherInterface
+{
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    /**
+     * @param string $pattern
+     */
+    public function __construct($pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    /**
+     * @param Request $request
+     * @return bool
+     */
+    public function isOfficialTiqrMobileApp(Request $request)
+    {
+        $userAgent = $request->headers->get('User-Agent');
+
+        return preg_match($this->pattern, $userAgent);
+    }
+}

--- a/src/AppBundle/Service/UserAgentMatcherInterface.php
+++ b/src/AppBundle/Service/UserAgentMatcherInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace AppBundle\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface UserAgentMatcherInterface
+{
+    /**
+     * @param Request $request
+     * @return bool
+     */
+    public function isOfficialTiqrMobileApp(Request $request);
+}


### PR DESCRIPTION
A new paramters.yml setting `mobile_app_user_agent_pattern` is checked
against the user agent received from the mobile app during
registration. If the pattern does not match, an error response is
returned. The default pattern allows any user agent string.

See [pivotal](https://www.pivotaltracker.com/story/show/133169279).