### PR TITLE
Specify allowed request methods on controller actions

### DIFF
--- a/src/AppBundle/Controller/AuthenticationController.php
+++ b/src/AppBundle/Controller/AuthenticationController.php
@@ -65,7 +65,7 @@ class AuthenticationController extends Controller
     }
 
     /**
-     * @Route("/authentication", name="app_identity_authentication")
+     * @Route("/authentication", name="app_identity_authentication", methods={"GET", "POST"})
      * @throws \InvalidArgumentException
      */
     public function authenticationAction(Request $request)
@@ -151,7 +151,7 @@ class AuthenticationController extends Controller
     }
 
     /**
-     * @Route("/authentication/status", name="app_identity_authentication_status")
+     * @Route("/authentication/status", name="app_identity_authentication_status", methods={"GET"})
      * @throws \InvalidArgumentException
      */
     public function authenticationStatusAction()
@@ -230,7 +230,7 @@ class AuthenticationController extends Controller
 
     /**
      *
-     * @Route("/authentication/qr", name="app_identity_authentication_qr")
+     * @Route("/authentication/qr", name="app_identity_authentication_qr", methods={"GET"})
      * @throws \InvalidArgumentException
      */
     public function authenticationQrAction()

--- a/src/AppBundle/Controller/CancelController.php
+++ b/src/AppBundle/Controller/CancelController.php
@@ -41,7 +41,7 @@ class CancelController extends Controller
     }
 
     /**
-     * @Route("/cancel", name="app_cancel")
+     * @Route("/cancel", name="app_cancel", methods={"GET"})
      * @throws \InvalidArgumentException
      */
     public function cancelAction()

--- a/src/AppBundle/Controller/InfoController.php
+++ b/src/AppBundle/Controller/InfoController.php
@@ -37,7 +37,7 @@ class InfoController extends Controller
     }
 
     /**
-     * @Route("/info.html", name="app_info")
+     * @Route("/info.html", name="app_info", methods={"GET"})
      */
     public function infoAction()
     {

--- a/src/AppBundle/Controller/RegistrationController.php
+++ b/src/AppBundle/Controller/RegistrationController.php
@@ -48,7 +48,7 @@ class RegistrationController extends Controller
     /**
      * Returns the registration page with QR code that is generated in 'qrRegistrationAction'.
      *
-     * @Route("/registration", name="app_identity_registration")
+     * @Route("/registration", name="app_identity_registration", methods={"GET", "POST"})
      *
      * @throws \InvalidArgumentException
      */
@@ -80,7 +80,7 @@ class RegistrationController extends Controller
     /**
      * For client-side polling retrieving the status.
      *
-     * @Route("/registration/status", name="app_identity_registration_status")
+     * @Route("/registration/status", name="app_identity_registration_status", methods={"GET"})
      *
      * @throws \InvalidArgumentException
      */
@@ -106,7 +106,8 @@ class RegistrationController extends Controller
      *
      * @see /registration/qr/link
      *
-     * @Route("/registration/qr", name="app_identity_registration_qr")
+     * @Route("/registration/qr", name="app_identity_registration_qr", methods={"GET"})
+     *
      * @throws \InvalidArgumentException
      */
     public function registrationQrAction(Request $request)

--- a/src/DevTiqrClientBundle/Controller/QrLinkController.php
+++ b/src/DevTiqrClientBundle/Controller/QrLinkController.php
@@ -38,7 +38,7 @@ final class QrLinkController extends Controller
     /**
      * Returns the QR for registration without an active authNRequest.
      *
-     * @Route("/registration/qr/dev", name="app_identity_registration_qr_dev")
+     * @Route("/registration/qr/dev", name="app_identity_registration_qr_dev", methods={"GET"})
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
@@ -52,7 +52,7 @@ final class QrLinkController extends Controller
     /**
      * Returns the link for registration without an active authNRequest.
      *
-     * @Route("/registration/qr/link", name="app_identity_registration_qr_link")
+     * @Route("/registration/qr/link", name="app_identity_registration_qr_link", methods={"GET"})
      * @param Request $request
      * @return Response
      * @throws \InvalidArgumentException
@@ -74,7 +74,7 @@ final class QrLinkController extends Controller
     /**
      * Returns the QR without an active authNRequest.
      *
-     * @Route("/authentication/qr/{nameId}", name="app_identity_authentication_qr_dev")
+     * @Route("/authentication/qr/{nameId}", name="app_identity_authentication_qr_dev", methods={"GET"})
      * @param string $nameId
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
@@ -87,7 +87,7 @@ final class QrLinkController extends Controller
     /**
      * Returns the link without an active authNRequest.
      *
-     * @Route("/authentication/qr/{nameId}/link", name="app_identity_authentication_qr_link")
+     * @Route("/authentication/qr/{nameId}/link", name="app_identity_authentication_qr_link", methods={"GET"})
      * @param string $nameId
      * @return Response
      */

--- a/src/SpBundle/Controller/SPController.php
+++ b/src/SpBundle/Controller/SPController.php
@@ -62,9 +62,9 @@ final class SPController extends Controller
     }
 
     /**
-     * @Route("/demo/sp", name="sp_demo")
+     * @Route("/demo/sp", name="sp_demo", methods={"GET", "POST"})
      *
-     * See @see RegistrationService for a more clean example.
+     * @see RegistrationService for a more clean example.
      *
      * @throws \Exception
      */
@@ -104,7 +104,7 @@ final class SPController extends Controller
     }
 
     /**
-     * @Route("/demo/sp/acs", name="sp_demo_acs")
+     * @Route("/demo/sp/acs", name="sp_demo_acs", methods={"POST"})
      *
      * See @see RegistrationService for a more clean example.
      */


### PR DESCRIPTION
All controller actions now have explicit rules as to how they can be
used. This was one of the points of feedback from the security audit.

The actions have been configured as can be seen in the `debug:router` output:

```
 ------------------------------------------ ---------- -------- ------ ----------------------------------- 
  Name                                       Method     Scheme   Host   Path                               
 ------------------------------------------ ---------- -------- ------ ----------------------------------- 
  _wdt                                       ANY        ANY      ANY    /_wdt/{token}                      
  _profiler_home                             ANY        ANY      ANY    /_profiler/                        
  _profiler_search                           ANY        ANY      ANY    /_profiler/search                  
  _profiler_search_bar                       ANY        ANY      ANY    /_profiler/search_bar              
  _profiler_phpinfo                          ANY        ANY      ANY    /_profiler/phpinfo                 
  _profiler_search_results                   ANY        ANY      ANY    /_profiler/{token}/search/results  
  _profiler_open_file                        ANY        ANY      ANY    /_profiler/open                    
  _profiler                                  ANY        ANY      ANY    /_profiler/{token}                 
  _profiler_router                           ANY        ANY      ANY    /_profiler/{token}/router          
  _profiler_exception                        ANY        ANY      ANY    /_profiler/{token}/exception       
  _profiler_exception_css                    ANY        ANY      ANY    /_profiler/{token}/exception.css   
  _twig_error_test                           ANY        ANY      ANY    /_error/{code}.{_format}           
  app_identity_authentication                GET|POST   ANY      ANY    /authentication                    
  app_identity_authentication_status         GET        ANY      ANY    /authentication/status             
  app_identity_authentication_qr             GET        ANY      ANY    /authentication/qr                 
  app_cancel                                 GET        ANY      ANY    /cancel                            
  app_info                                   GET        ANY      ANY    /info.html                         
  app_identity_registration                  GET|POST   ANY      ANY    /registration                      
  app_identity_registration_status           GET        ANY      ANY    /registration/status               
  app_identity_registration_qr               GET        ANY      ANY    /registration/qr                   
  app_identity_registration_metadata         GET        ANY      ANY    /tiqr.php                          
  app_tiqrappapi_metadata                    GET        ANY      ANY    /tiqr/tiqr.php                     
  app_identity_registration_authentication   POST       ANY      ANY    /tiqr.php                          
  app_tiqrappapi_tiqr                        POST       ANY      ANY    /tiqr/tiqr.php                     
  gssp_saml_metadata                         GET        ANY      ANY    /saml/metadata                     
  gssp_saml_sso                              GET        ANY      ANY    /saml/sso                          
  gssp_saml_sso_return                       POST|GET   ANY      ANY    /saml/sso_return                   
  sp_demo                                    GET|POST   ANY      ANY    /demo/sp                           
  sp_demo_acs                                POST       ANY      ANY    /demo/sp/acs                       
  app_identity_registration_qr_dev           GET        ANY      ANY    /registration/qr/dev               
  app_identity_registration_qr_link          GET        ANY      ANY    /registration/qr/link              
  app_identity_authentication_qr_dev         GET        ANY      ANY    /authentication/qr/{nameId}        
  app_identity_authentication_qr_link        GET        ANY      ANY    /authentication/qr/{nameId}/link   
 ------------------------------------------ ---------- -------- ------ ----------------------------------- 
```

Note that the routes prefixed with an underscore are not available in production mode. They are related to the Symfony profiler which should be disabled in prod mode.

See: https://www.pivotaltracker.com/story/show/158356676