### PR TITLE
Install the monitor bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,6 +16,10 @@ class AppKernel extends Kernel
             new Surfnet\SamlBundle\SurfnetSamlBundle(),
             new Surfnet\StepupBundle\SurfnetStepupBundle(),
             new Surfnet\GsspBundle\SurfnetGsspBundle(),
+
+            // OpenConext Monitor integration
+            new OpenConext\MonitorBundle\OpenConextMonitorBundle(),
+
             new AppBundle\AppBundle(),
         ];
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -4,3 +4,7 @@ app:
 
 gssp_saml:
     resource: '@SurfnetGsspBundle/Resources/config/routing.yml'
+
+openconext_monitor:
+    resource:   "@OpenConextMonitorBundle/Resources/config/routing.yml"
+    prefix:     /

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -13,6 +13,10 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         main:
             anonymous: ~
             logout_on_user_change: true

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "incenteev/composer-parameter-handler": "^2.0",
         "kairos/phpqrcode": "^1.0",
         "liip/rmt": "^1.2",
+        "openconext/monitor-bundle": "^1.0",
         "sensio/distribution-bundle": "^5.0.19",
         "sensio/framework-extra-bundle": "^3.0.2",
         "surfnet/stepup-bundle": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8eb177bea3fe3c66293c78486dcf625",
+    "content-hash": "0bc0cff1a69d426229c0961f57def9e6",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -986,6 +986,59 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "openconext/monitor-bundle",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/Monitor-bundle.git",
+                "reference": "b5cc6d3bf245e0a454b5a09a53d9919e5ec9cc23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/b5cc6d3bf245e0a454b5a09a53d9919e5ec9cc23",
+                "reference": "b5cc6d3bf245e0a454b5a09a53d9919e5ec9cc23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4,<8.0-dev",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4",
+                "webmozart/assert": "^1.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "liip/rmt": "^1.1",
+                "malukenho/docheader": "^0.1.6",
+                "matthiasnoback/symfony-config-test": "^2.1",
+                "mockery/mockery": "~0.9",
+                "phpdocumentor/reflection-docblock": "3.3.*",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/php-token-stream": "1.4.*",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^3.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "OpenConext\\MonitorBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A Symfony 3 bundle that facilitates health and info endpoints to a Symfony application. The bundle is backwards compatible with Symfony 2 projects.",
+            "keywords": [
+                "OpenConext",
+                "health",
+                "monitoring",
+                "stepup",
+                "surfnet"
+            ],
+            "time": "2017-12-18T15:17:50+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2740,6 +2793,56 @@
                 "versioning"
             ],
             "time": "2017-07-11T09:53:59+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "zendframework/zendframework1",
@@ -5462,56 +5565,6 @@
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
             "time": "2017-06-30T11:53:12+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
The bundle was added as a composer dependency, installed in the project
and configured to serve health and info information on the /health and
/info endpoints.

See https://www.pivotaltracker.com/story/show/156880260