### PR TITLE
Use system session-handler by default

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -26,8 +26,7 @@ framework:
     trusted_hosts: ~
     session:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
-        handler_id: session.handler.native_file
-        save_path: null
+        handler_id: ~
     fragments: ~
     http_method_override: true
     assets: ~


### PR DESCRIPTION
Setting this to `session.handler.native_file` by default will fail on systems that have set something other than 'files' as `session.save_handler` in php.ini. Using the system default should always work.

This is in line with the other OC/stepup components