### PR TITLE
Move js logic & disable polling on error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,9 +76,10 @@
             "@jest"
         ],
 
-        "lint": ["@lint-php", "@lint-yml", "@lint-composer"],
+        "lint": ["@lint-php", "@lint-yml", "@lint-composer", "@lint-ts"],
         "lint-php": "vendor/bin/parallel-lint app src",
         "lint-yml": "bin/console lint:yaml app/config",
+        "lint-ts": "yarn tslint --project tsconfig.json",
         "lint-composer": "composer validate",
 
         "static-analysis": ["@license-headers", "@phpmd", "@phpcs", "@phpcpd"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     ],
     transform: {
         "^.+\\.(js)$": "<rootDir>/node_modules/babel-jest",
-        "\\.(ts|tsx)$": "ts-jest/preprocessor.js"
+        "\\.(ts|tsx)$": "ts-jest"
     },
     testRegex: ".*\\.test\\.(ts|tsx|js|jsx)$",
     globals: {

--- a/src/AppBundle/Resources/javascript/Component/RegistrationStatusComponent.ts
+++ b/src/AppBundle/Resources/javascript/Component/RegistrationStatusComponent.ts
@@ -1,0 +1,62 @@
+import 'jquery';
+
+export class RegistrationStatusComponent {
+
+  /**
+   * Your session has expired.
+   * Refresh the page and try again.
+   * Or click 'Cancel' to return to Home
+   */
+  public showExpiredSessionStatus() {
+    this.show('ul.status.expired');
+  }
+
+  /**
+   * Open the tiqr app on your phone.
+   * Scan the QR code with the tiqr app.
+   */
+  public showOpenTiqrApp() {
+    this.show('ul.status.initialized');
+  }
+
+  /**
+   * The 'Account activation' page will appear on your phone.
+   * Click 'OK' in the tiqr app to activate your account.
+   * Create a PIN for your tiqr account<br/>Please memorise your PIN, this PIN cannot be changed later.
+   * After entering your PIN in the tiqr app you will proceed to the next step automatically.
+   */
+  public showAccountActivationHelp() {
+    this.show('ul.status.retrieved');
+  }
+
+  /**
+   * One moment please...
+   */
+  public showOneMomentPlease() {
+    this.show('div.status.processed');
+  }
+
+  /**
+   * Finalized.
+   */
+  public showFinalized() {
+    this.show('div.status.finalized');
+  }
+
+  /**
+   * Unknown error happened. Please try again by refreshing your browser.
+   */
+  public showUnknownErrorHappened() {
+    this.show('div.status.error');
+  }
+
+  private hideAll() {
+    jQuery('.status-container >').hide();
+  }
+
+  private show(selector: string) {
+    this.hideAll();
+    jQuery(selector).show();
+  }
+
+}

--- a/src/AppBundle/Resources/javascript/RegistrationStateMachine.ts
+++ b/src/AppBundle/Resources/javascript/RegistrationStateMachine.ts
@@ -1,0 +1,83 @@
+import { StatusPollService } from './StatusPollService';
+import { RegistrationStatusComponent } from './Component/RegistrationStatusComponent';
+import { Component } from './Component/Component';
+
+export class RegistrationStateMachine {
+  public static readonly IDLE = '1';
+  public static readonly INITIALIZED = '2';
+  public static readonly RETRIEVED = '3';
+  public static readonly PROCESSED = '4';
+  public static readonly FINALIZED = '5';
+  /**
+   * Client-side only status.
+   */
+  public static readonly ERROR = 'ERROR';
+  private previousStatus = RegistrationStateMachine.IDLE;
+
+  constructor(private statusPollingService: StatusPollService,
+              private statusUi: RegistrationStatusComponent,
+              private qrCode: Component,
+              private finalizedUrl: string) {
+  }
+
+  public start() {
+    this.scheduleNextPoll();
+    this.statusUi.showOpenTiqrApp();
+  }
+
+  /**
+   * This will handle the status given by the RegistrationController.registrationStatusAction.
+   */
+  private statusReceivedHandler = (status: string) => {
+    switch (status) {
+      case RegistrationStateMachine.IDLE:
+        if (this.previousStatus !== RegistrationStateMachine.IDLE) {
+          this.qrCode.hide();
+          this.statusPollingService.stop();
+          this.statusUi.showExpiredSessionStatus();
+          this.previousStatus = RegistrationStateMachine.ERROR;
+          return;
+        }
+        this.statusUi.showOpenTiqrApp();
+        this.scheduleNextPoll();
+        break;
+      case RegistrationStateMachine.INITIALIZED:
+        this.statusUi.showOpenTiqrApp();
+        this.qrCode.show();
+        this.scheduleNextPoll();
+        break;
+      case RegistrationStateMachine.RETRIEVED:
+        this.statusUi.showAccountActivationHelp();
+        this.scheduleNextPoll();
+        this.qrCode.hide();
+        break;
+      case RegistrationStateMachine.PROCESSED:
+        this.statusUi.showOneMomentPlease();
+        this.scheduleNextPoll();
+        this.qrCode.hide();
+        break;
+      case RegistrationStateMachine.FINALIZED:
+        this.statusPollingService.stop();
+        this.statusUi.showFinalized();
+        this.qrCode.hide();
+        document.location.replace(this.finalizedUrl);
+        break;
+      default:
+        this.unknownError();
+        return;
+    }
+    this.previousStatus = status;
+  };
+
+  private scheduleNextPoll() {
+    this.statusPollingService.waitAndRequestStatus(this.statusReceivedHandler, this.unknownError);
+  }
+
+  private unknownError = () => {
+    this.qrCode.hide();
+    this.statusUi.showUnknownErrorHappened();
+    this.statusPollingService.stop();
+    this.previousStatus = RegistrationStateMachine.ERROR;
+  };
+
+}

--- a/src/AppBundle/Resources/javascript/__test__/RegistrationPageService.test.ts
+++ b/src/AppBundle/Resources/javascript/__test__/RegistrationPageService.test.ts
@@ -1,0 +1,263 @@
+import 'jest';
+import { RegistrationStateMachine } from '../RegistrationStateMachine';
+
+describe('RegistrationPageService', () => {
+  let statusCallback: ((status: string) => void) | undefined;
+  let errorCallback: ((error: unknown) => void) | undefined;
+  let context = createTestContext();
+
+  beforeEach(() => {
+    context = createTestContext();
+  });
+
+  describe('When starting', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be enabled', () => {
+      expect(context.pollingService.enabled).toBeTruthy();
+    });
+
+    it('The tiqr app help function should be shown', () => {
+      expect(context.statusUi.showOpenTiqrApp).toBeCalled();
+    });
+  });
+
+  describe('When idle', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.IDLE);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be enabled', () => {
+      expect(context.pollingService.enabled).toBeTruthy();
+    });
+
+    it('Show open tiqr app', () => {
+      expect(context.statusUi.showOpenTiqrApp).toBeCalled();
+    });
+  });
+
+  describe('When initialized', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.INITIALIZED);
+    });
+
+    it('The qr code should be shown', () => {
+      expect(context.qrComponent.isVisible()).toBeTruthy();
+    });
+
+    it('Polling should be enabled', () => {
+      expect(context.pollingService.enabled).toBeTruthy();
+    });
+
+    it('Show open tiqr app', () => {
+      expect(context.statusUi.showOpenTiqrApp).toBeCalled();
+    });
+  });
+
+  describe('When retrieved', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.RETRIEVED);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be enabled', () => {
+      expect(context.pollingService.enabled).toBeTruthy();
+    });
+
+    it('Show account activation help', () => {
+      expect(context.statusUi.showAccountActivationHelp).toBeCalled();
+    });
+  });
+
+  describe('When processed', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.PROCESSED);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be enabled', () => {
+      expect(context.pollingService.enabled).toBeTruthy();
+    });
+
+    it('Show one moment please', () => {
+      expect(context.statusUi.showOneMomentPlease).toBeCalled();
+    });
+  });
+
+  describe('When finalized', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      window.document.location.replace = jest.fn();
+      statusCallback(RegistrationStateMachine.FINALIZED);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be disabled', () => {
+      expect(context.pollingService.enabled).toBeFalsy();
+    });
+
+    it('Show finalized', () => {
+      expect(context.statusUi.showFinalized).toBeCalled();
+    });
+
+    it('Redirect to finalized page', () => {
+      expect(window.document.location.replace).toBeCalledWith('http://fake-finalized-url.com');
+    });
+  });
+
+  describe('When connection error occurred', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      errorCallback('error');
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be disabled', () => {
+      expect(context.pollingService.enabled).toBeFalsy();
+    });
+
+    it('Show error page', () => {
+      expect(context.statusUi.showUnknownErrorHappened).toBeCalled();
+    });
+  });
+
+  describe('When random status is given', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback('random status');
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be disabled', () => {
+      expect(context.pollingService.enabled).toBeFalsy();
+    });
+
+    it('Show error page', () => {
+      expect(context.statusUi.showUnknownErrorHappened).toBeCalled();
+    });
+  });
+
+  describe('When sessions time out', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.RETRIEVED);
+      statusCallback(RegistrationStateMachine.IDLE);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be disabled', () => {
+      expect(context.pollingService.enabled).toBeFalsy();
+    });
+
+    it('Show error page', () => {
+      expect(context.statusUi.showExpiredSessionStatus).toBeCalled();
+    });
+  });
+
+  function createTestContext() {
+    const pollingService = {
+      enabled: false,
+      waitAndRequestStatus: jest.fn(((success: any, error: any) => {
+        statusCallback = success;
+        errorCallback = error;
+        (pollingService as any).enabled = true;
+      })),
+      stop: jest.fn(() => {
+        (pollingService as any).enabled = false;
+      }),
+    };
+
+    const registrationStatusComponent = {
+      showExpiredSessionStatus: jest.fn(),
+      showOpenTiqrApp: jest.fn(),
+      showAccountActivationHelp:jest.fn(),
+      showOneMomentPlease: jest.fn(),
+      showFinalized: jest.fn(),
+      showUnknownErrorHappened: jest.fn(),
+    };
+
+    function createMockComponent() {
+      let visible = false;
+      return {
+        isVisible: () => visible,
+        show: () => {
+          visible = true;
+        },
+        hide: () => {
+          visible = false;
+        },
+      };
+    }
+
+    const qrComponent = createMockComponent();
+
+    const authenticationPageService = new RegistrationStateMachine(
+      pollingService as any,
+      registrationStatusComponent as any,
+      qrComponent,
+      'http://fake-finalized-url.com',
+    );
+    return {
+      pollingService,
+      authenticationPageService,
+      statusUi: registrationStatusComponent,
+      qrComponent,
+    };
+  }
+});

--- a/src/AppBundle/Resources/javascript/registration.ts
+++ b/src/AppBundle/Resources/javascript/registration.ts
@@ -1,0 +1,24 @@
+import { RegistrationStateMachine } from './RegistrationStateMachine';
+import { StatusClient } from './Client/StatusClient';
+import { StatusPollService } from './StatusPollService';
+import { RegistrationStatusComponent } from './Component/RegistrationStatusComponent';
+import { SlideableComponent } from './Component/SlideableComponent';
+
+declare global {
+  interface Window {
+    bootstrapRegistration: (statusApiUrl: string, notificationApiUrl: string) => RegistrationStateMachine;
+  }
+}
+
+window.bootstrapRegistration = (statusApiUrl: string, finalizedUrl: string) => {
+  const statusClient = new StatusClient(statusApiUrl);
+  const pollingService = new StatusPollService(statusClient);
+  const machine = new RegistrationStateMachine(
+    pollingService,
+    new RegistrationStatusComponent(),
+    new SlideableComponent(jQuery('.qr')),
+    finalizedUrl,
+  );
+  machine.start();
+  return machine;
+};

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -37,6 +37,7 @@ login:
 
 enrol:
     title: Register new tiqr account
+    retry: Try again.
     status:
         idle.1: Your session has expired.
         idle.2: Refresh the page and try again.

--- a/src/AppBundle/Resources/translations/messages.nl.yml
+++ b/src/AppBundle/Resources/translations/messages.nl.yml
@@ -41,6 +41,7 @@ login:
 
 enrol:
     title: Registreer nieuw tiqr-account
+    retry: Probeer opnieuw.
     status:
         idle.1: Je sessie is verlopen.
         idle.2: Ververs de pagina om nogmaals te proberen.

--- a/src/AppBundle/Resources/views/default/registration.html.twig
+++ b/src/AppBundle/Resources/views/default/registration.html.twig
@@ -10,7 +10,7 @@
 
 {% block body %}
     <div class="content-container status-container">
-        <ul class="status idle">
+        <ul class="status expired">
             <li>{{ 'enrol.status.idle.1' | trans }}</li>
             <li>{{ 'enrol.status.idle.2' | trans }}</li>
             <li>{{ 'enrol.status.idle.3' | trans }}</li>
@@ -33,81 +33,18 @@
         </div>
         <div class="status error">
             {{ 'enrol.status.error' | trans }}
+            <a href="{{  path('app_identity_registration') }}">{{ 'enrol.retry' | trans }}</a>.
         </div>
     </div>
     <div class="content-container qr">
         <img src="{{ url('app_identity_registration_qr') }}">
         {{ 'enrol.download' | trans | raw }}
     </div>
-
+    <script src="{{ asset('build/registration.js') }}" ></script>
     <script>
-        jQuery(function () {
-            var idle = "1";
-            var initialized = "2";
-            var retrieved = "3";
-            var processed = "4";
-            var finalized = "5";
-
-            // Remember if registration has been initialized on the server.
-            // If this is NOT the case, and we can an IDLE status back, we know initialization is not yet started.
-            // If this IS the case, we know something went wrong (probably session expired).
-            var hasBeenInitialized = false;
-
-            function fadeoutQr() {
-                jQuery(".qr").hide("slow");
-            }
-
-            function updateStatusText(selector) {
-                hasBeenInitialized = true;
-                jQuery('.status-container >').hide();
-                jQuery(selector).show();
-            }
-
-            function scheduleNextPoll() {
-                setTimeout(requestStatus, 1500);
-            }
-
-            function updateStatus(status) {
-                switch (status) {
-                    case idle:
-                        if (hasBeenInitialized) {
-                            updateStatusText('ul.status.idle');
-                            fadeoutQr();
-                        }
-                        scheduleNextPoll();
-                        break;
-                    case initialized:
-                        updateStatusText('ul.status.initialized');
-                        scheduleNextPoll();
-                        break;
-                    case retrieved:
-                        updateStatusText('ul.status.retrieved');
-                        scheduleNextPoll();
-                        fadeoutQr();
-                        break;
-                    case processed:
-                        updateStatusText('div.status.processed');
-                        scheduleNextPoll();
-                        fadeoutQr();
-                        break;
-                    case finalized:
-                        updateStatusText('div.status.finalized');
-                        scheduleNextPoll();
-                        fadeoutQr();
-                        document.location = "{{ path('app_identity_registration') | escape('js') }}";
-                        break;
-                    default:
-                        updateStatusText("div.status.error");
-                        scheduleNextPoll();
-                }
-            }
-
-            function requestStatus() {
-                var statusUrl = "{{ path('app_identity_registration_status') | escape('js') }}";
-                jQuery.get(statusUrl, updateStatus);
-            }
-
-            requestStatus();
-        });
+        var registrationStateMachine = bootstrapRegistration(
+            "{{ path('app_identity_registration_status') | escape('js') }}",
+            "{{ path('app_identity_registration') | escape('js') }}",
+        );
     </script>
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,8 @@ Encore
     .autoProvidejQuery()
     .addStyleEntry('global', './app/Resources/scss/application.scss')
     .addEntry('authentication', './src/AppBundle/Resources/javascript/authentication.ts')
+    .addEntry('registration', './src/AppBundle/Resources/javascript/registration.ts')
+
     // Convert sass files.
     .enableSassLoader(function (options) {
         // https://github.com/sass/node-sass#options.


### PR DESCRIPTION
Test scenario:

- Registreer en wacht totdat sessie verloop.
  - Session expired
  - Polling moet uit staan.
- Ga offline (in browser)
  - Fout melding scherm
  - Polling moet uit staan.

Je kan ook testen met js console met:

registrationStateMachine.statusReceivedHandler('3') // Tot 1-5

See: https://www.pivotaltracker.com/story/show/160949726
