### PR TITLE
Fix tiqr authentication status

### DIFF
--- a/src/AppBundle/Controller/AuthenticationController.php
+++ b/src/AppBundle/Controller/AuthenticationController.php
@@ -164,10 +164,6 @@ class AuthenticationController extends Controller
             return $this->refreshAuthenticationPage();
         }
 
-        if ($this->authenticationChallengeIsExpired()) {
-            return $this->timeoutNeedsManualRetry();
-        }
-
         $isAuthenticated = $this->tiqrService->isAuthenticated();
 
         if ($isAuthenticated) {
@@ -175,6 +171,11 @@ class AuthenticationController extends Controller
 
             return $this->refreshAuthenticationPage();
         }
+
+        if ($this->authenticationChallengeIsExpired()) {
+            return $this->timeoutNeedsManualRetry();
+        }
+
         $this->logger->info('Send json response is not authenticated');
 
         return $this->scheduleNextPollOnAuthenticationPage();


### PR DESCRIPTION
The status of the Tiqr authentication was not returned after it
was successful because it would return an expired status as the
check depended on a Memcache value which was cleared after success so
the status returned an expired state. The logic order was changed so
first, we check for successful authentication and after that we check
if it's expired.