### PR TITLE
Prevent XXE in SPController

### DIFF
--- a/src/SpBundle/Controller/SPController.php
+++ b/src/SpBundle/Controller/SPController.php
@@ -154,10 +154,12 @@ final class SPController extends Controller
      */
     private function toFormattedXml($xml)
     {
+        $previous = libxml_disable_entity_loader(true);
         $domxml = new DOMDocument('1.0');
         $domxml->preserveWhiteSpace = false;
         $domxml->formatOutput = true;
         $domxml->loadXML($xml);
+        libxml_disable_entity_loader($previous);
 
         return $domxml->saveXML();
     }


### PR DESCRIPTION
By disabling the entity loader, we prevent possible XXE exploitations. After disabling the loader, the previous state is reset.