### PR TITLE
Remove modern js from twig templates

### DIFF
--- a/src/AppBundle/Resources/views/default/authentication.html.twig
+++ b/src/AppBundle/Resources/views/default/authentication.html.twig
@@ -77,7 +77,7 @@
          */
         var authenticationPageService = bootstrapAuthentication(
             "{{ path('app_identity_authentication_status') | escape('js') }}",
-            "{{ path('app_identity_authentication_notification') | escape('js') }}",
+            "{{ path('app_identity_authentication_notification') | escape('js') }}"
         );
     </script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/default/registration.html.twig
+++ b/src/AppBundle/Resources/views/default/registration.html.twig
@@ -44,7 +44,7 @@
     <script>
         var registrationStateMachine = bootstrapRegistration(
             "{{ path('app_identity_registration_status') | escape('js') }}",
-            "{{ path('app_identity_registration') | escape('js') }}",
+            "{{ path('app_identity_registration') | escape('js') }}"
         );
     </script>
 {% endblock %}

--- a/src/SpBundle/Resources/views/default/sp.html.twig
+++ b/src/SpBundle/Resources/views/default/sp.html.twig
@@ -51,7 +51,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script>
-        jQuery('#locale-cookie').on('change', (input) => {
+        jQuery('#locale-cookie').on('change', function (input) {
             Cookies.set('stepup_locale', input.target.value);
         });
     </script>


### PR DESCRIPTION
To ensure good browser compatibility, any JS that is not transpiled by Babel, should be checked and fixed. We should not use any ES6 or newer language constructions.

For more details see the individual commit messages and the Pivotal ticket.

https://www.pivotaltracker.com/story/show/164629776