### PR TITLE
Enable asset versioning using Encore

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,7 +29,8 @@ framework:
         handler_id: ~
     fragments: ~
     http_method_override: true
-    assets: ~
+    assets:
+        json_manifest_path: '%kernel.project_dir%/web/build/manifest.json'
     php_errors:
         log: true
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,9 @@ Encore
             }
         ]
     })
-    .enableSourceMaps();
+    .enableSourceMaps()
+    .enableVersioning();
+
 
 module.exports = Encore.getWebpackConfig();
 module.exports.externals = {


### PR DESCRIPTION
Implement asset versioning as described in the Symfony docs: https://symfony.com/doc/current/frontend/encore/versioning.html. This solution differs from the way other StepUp apps apply asset versioning. This because these apps use Assetic (which is discouraged since Symfony embraced Encore). 

Also see Pivotal
https://www.pivotaltracker.com/story/show/164631198