### PR TITLE
Add ECMAScript 3 support

### DIFF
--- a/src/AppBundle/Resources/javascript/authentication.ts
+++ b/src/AppBundle/Resources/javascript/authentication.ts
@@ -33,7 +33,9 @@ window.bootstrapAuthentication = (statusApiUrl: string, notificationApiUrl: stri
     statusErrorComponent,
     notificationErrorComponent,
   );
+
   authenticationPageService.switchToPolling();
+
   return authenticationPageService;
 };
 

--- a/src/AppBundle/Resources/views/default/authentication.html.twig
+++ b/src/AppBundle/Resources/views/default/authentication.html.twig
@@ -75,7 +75,7 @@
         /**
          * @var {AuthenticationPageService} authenticationPageService
          */
-        var authenticationPageService = bootstrapAuthentication(
+        var authenticationPageService = window.bootstrapAuthentication(
             "{{ path('app_identity_authentication_status') | escape('js') }}",
             "{{ path('app_identity_authentication_notification') | escape('js') }}"
         );

--- a/src/AppBundle/Resources/views/default/registration.html.twig
+++ b/src/AppBundle/Resources/views/default/registration.html.twig
@@ -42,7 +42,7 @@
     </div>
     <script src="{{ asset('build/registration.js') }}" ></script>
     <script>
-        var registrationStateMachine = bootstrapRegistration(
+        var registrationStateMachine = window.bootstrapRegistration(
             "{{ path('app_identity_registration_status') | escape('js') }}",
             "{{ path('app_identity_registration') | escape('js') }}"
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "es3",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,20 @@ Encore
     .addEntry('authentication', './src/AppBundle/Resources/javascript/authentication.ts')
     .addEntry('registration', './src/AppBundle/Resources/javascript/registration.ts')
 
+    // Disable minification to support ie8
+    .configureUglifyJsPlugin(function (options) {
+        options.ie8 = true;
+        options.compress = {
+            screw_ie8: false,
+        };
+        options.mangleProperties = {
+            screw_ie8: false,
+        };
+        options.output = {
+            screw_ie8: false,
+        };
+    })
+
     // Convert sass files.
     .enableSassLoader(function (options) {
         // https://github.com/sass/node-sass#options.


### PR DESCRIPTION
When TS was introduced TS was compiled to ECMASCRIPT 5. In older
browsers this seems a problem. Therefore now we compile TS to
ECMASCRIPT 3 to keep older browsers supported.