### PR TITLE
Test php 7.3 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,14 @@ addons:
 
 php:
   - 5.6
+  - 7.2
   - 7.3
+
+
+matrix:
+  allow_failures:
+    - php: 7.2
+    - php: 7.3
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ addons:
 
 php:
   - 5.6
-  - 7.0
-  - 7.1
+  - 7.3
 
 cache:
   directories:


### PR DESCRIPTION
This is done in order to be able to test behavior on php 7.3 to
explore possible php migration issues.