### PR TITLE
Use FCM always as fallback for GCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+## 2.1.14
+ * Use FCM always as fallback for GCM #80
+ 
 ## 2.1.13
  * Update symfony/symfony and symfony/phpunit-bridge #79
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -38,10 +38,6 @@ parameters:
     # PCRE as accepted by preg_match (http://php.net/preg_match).
     mobile_app_user_agent_pattern: "/^.*$/"
 
-    # Flag to use Firebse as fallback when GCM fails with a MismatchSenderId.
-    # This is used to handle the push notification method rollover from GCM to Firebase.
-    use_firebase_fallback_for_gcm: true
-
     # Options for the tiqr library
     tiqr_library_options:
         general:

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -56,7 +56,3 @@ services:
     AppBundle\Service\UserAgentMatcher:
       bind:
         $pattern: '%mobile_app_user_agent_pattern%'
-
-    AppBundle\Controller\AuthenticationController:
-      bind:
-        $useFirebaseFallbackForGcm: '%use_firebase_fallback_for_gcm%'


### PR DESCRIPTION
This should fix the deprecated GCM method. The api is returning a
`Error=DeprecatedEndpoint` error which prevents GCM users from
logging in.