### PR TITLE
Use location.reload() to prevent rare chrome issue

### DIFF
--- a/public/typescript/AuthenticationPageService.ts
+++ b/public/typescript/AuthenticationPageService.ts
@@ -92,7 +92,7 @@ export class AuthenticationPageService {
 
   /* istanbul ignore next */
   public reloadPage() {
-    document.location.replace(document.location.href);
+    location.reload();
   }
 
   /**


### PR DESCRIPTION
In some rare conditions (chrome browser, only tiqr-token, coming from portal.office.com, etc) `document.location.replace(document.location.href);` does not seem to work. Using `location.reload();` seems to fix this.
_SURF issue CXT-50235_