### PR TITLE
Fix a fatal error in the exception controller

### DIFF
--- a/src/Controller/ExceptionController.php
+++ b/src/Controller/ExceptionController.php
@@ -78,7 +78,7 @@ final class ExceptionController extends BaseExceptionController
     {
         $translator = $this->getTranslator();
 
-        if ($exception instanceof UnrecoverableErrorException) {
+        if ($exception instanceof UnrecoverableErrorException && $exception->getPrevious() !== null) {
             return $this->getPageTitleAndDescription($exception->getPrevious());
         } elseif ($exception instanceof UserNotFoundException) {
             $title = $translator->trans('login.error.user_not_found.title');


### PR DESCRIPTION
When a unrecoverable error is thrown without a previous exception the
exception controller which displays the error message fails with an
fatal error. This is due to the display handler expecting a previous
exception which is not always the case.

The fatal error is resolved by extending the if condition and checking
for existence of the previous error.

See: https://www.pivotaltracker.com/n/projects/1163646/stories/177016742