### PR TITLE
Resolve authentication issues due to duplicate notification call

### DIFF
--- a/templates/default/authentication.html.twig
+++ b/templates/default/authentication.html.twig
@@ -8,6 +8,19 @@
     {{ 'login.title'|trans }}
 {% endblock %}
 
+{% block javascripts %}
+    {{ encore_entry_script_tags('authentication') }}
+    <script>
+        /**
+         * @var {AuthenticationPageService} authenticationPageService
+         */
+        var authenticationPageService = window.bootstrapAuthentication(
+            "{{ path('app_identity_authentication_status') | escape('js') }}",
+            "{{ path('app_identity_authentication_notification') | escape('js') }}"
+        );
+    </script>
+{% endblock %}
+
 {% block body %}
     <div class="spinner-container">
         {{ 'login.qr.message' | trans }}
@@ -72,16 +85,4 @@
 
         <a onClick="authenticationPageService.reloadPage()">{{ 'login.retry' | trans }}</a>
     </div>
-    {% block javascripts %}
-        {{ encore_entry_script_tags('authentication') }}
-        <script>
-            /**
-             * @var {AuthenticationPageService} authenticationPageService
-             */
-            var authenticationPageService = window.bootstrapAuthentication(
-                "{{ path('app_identity_authentication_status') | escape('js') }}",
-                "{{ path('app_identity_authentication_notification') | escape('js') }}"
-            );
-        </script>
-    {% endblock %}
 {% endblock %}

--- a/templates/default/registration.html.twig
+++ b/templates/default/registration.html.twig
@@ -8,6 +8,16 @@
     {{ 'enrol.title'|trans }}
 {% endblock %}
 
+{% block javascripts %}
+    {{ encore_entry_script_tags('registration') }}
+    <script>
+        var registrationStateMachine = window.bootstrapRegistration(
+            "{{ path('app_identity_registration_status') | escape('js') }}",
+            "{{ path('app_identity_registration') | escape('js') }}"
+        );
+    </script>
+{% endblock %}
+
 {% block body %}
     <div class="content-container status-container">
         <ul class="status expired">
@@ -40,13 +50,4 @@
         <img src="{{ url('app_identity_registration_qr') }}">
         {{ 'enrol.download' | trans | raw }}
     </div>
-    {% block javascripts %}
-        {{ encore_entry_script_tags('registration') }}
-        <script>
-            var registrationStateMachine = window.bootstrapRegistration(
-                "{{ path('app_identity_registration_status') | escape('js') }}",
-                "{{ path('app_identity_registration') | escape('js') }}"
-            );
-        </script>
-    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Due to an issue in the twig template the javascript block was rendered
twice which could lead in a authentication error.

This moves the javascript block outside the body block which is also the
case in the parent template.

See: https://www.pivotaltracker.com/n/projects/1163646/stories/177016742