### PR TITLE
Repair the Exception show forward

### DIFF
--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -353,7 +353,7 @@ class AuthenticationController extends AbstractController
         }
         // Forward to the exception controller to prevent an error being logged.
         return $this->forward(
-            'App:Exception:show',
+            'App\Controller\ExceptionController::showAction',
             [
                 'exception'=> $exception,
             ]


### PR DESCRIPTION
The old school Symfony 3 forward was replaced with the modern FQN
counterpart.