### PR TITLE
Use the configured `usersecretstorage` storage type

### DIFF
--- a/src/Tiqr/Legacy/TiqrUser.php
+++ b/src/Tiqr/Legacy/TiqrUser.php
@@ -34,9 +34,10 @@ class TiqrUser implements TiqrUserInterface
     private $userStorage;
     private $userId;
 
-    public function __construct($userStorage, $userId)
+    public function __construct(Tiqr_UserStorage_Interface $userStorage, Tiqr_UserStorage_Interface $userSecretStorage, $userId)
     {
         $this->userStorage = $userStorage;
+        $this->userSecretStorage = $userSecretStorage;
         $this->userId = $userId;
     }
 
@@ -57,7 +58,7 @@ class TiqrUser implements TiqrUserInterface
      */
     public function getSecret()
     {
-        return $this->userStorage->getSecret($this->userId);
+        return $this->userSecretStorage->getSecret($this->userId);
     }
 
     public function updateNotification($notificationType, $notificationAddress)

--- a/src/Tiqr/Legacy/TiqrUserRepository.php
+++ b/src/Tiqr/Legacy/TiqrUserRepository.php
@@ -18,8 +18,8 @@
 namespace App\Tiqr\Legacy;
 
 use App\Tiqr\Exception\UserNotExistsException;
-use App\Tiqr\Legacy\TiqrUser;
 use App\Tiqr\TiqrUserRepositoryInterface;
+use Tiqr_UserStorage_Interface;
 
 /**
  * Wrapper around the legacy Tiqr user repository.
@@ -27,19 +27,26 @@ use App\Tiqr\TiqrUserRepositoryInterface;
 final class TiqrUserRepository implements TiqrUserRepositoryInterface
 {
     /**
-     * @var \Tiqr_UserStorage_Interface
+     * @var Tiqr_UserStorage_Interface
      */
     private $userStorage;
+    /**
+     * @var Tiqr_UserStorage_Interface
+     */
+    private $userSecretStorage;
 
-    public function __construct($userStorage)
-    {
+    public function __construct(
+        Tiqr_UserStorage_Interface $userStorage,
+        Tiqr_UserStorage_Interface $userSecretStorage
+    ) {
         $this->userStorage = $userStorage;
+        $this->userSecretStorage = $userSecretStorage;
     }
 
     public function createUser($userId, $secret)
     {
         $this->userStorage->createUser($userId, 'anonymous');
-        $this->userStorage->setSecret($userId, $secret);
+        $this->userSecretStorage->setSecret($userId, $secret);
         return $this->getUser($userId);
     }
 

--- a/src/Tiqr/Legacy/TiqrUserRepository.php
+++ b/src/Tiqr/Legacy/TiqrUserRepository.php
@@ -55,6 +55,6 @@ final class TiqrUserRepository implements TiqrUserRepositoryInterface
         if (!$this->userStorage->userExists($userId)) {
             throw UserNotExistsException::createFromId($userId);
         }
-        return new TiqrUser($this->userStorage, $userId);
+        return new TiqrUser($this->userStorage, $this->userSecretStorage, $userId);
     }
 }

--- a/src/Tiqr/TiqrFactory.php
+++ b/src/Tiqr/TiqrFactory.php
@@ -51,17 +51,17 @@ class TiqrFactory
         $this->loadDependencies();
         $options = $this->configuration->getTiqrOptions();
 
-        $storageType = "file";
-        $storageOptions = array();
+        $userStorageType = "file";
+        $userStorageOptions = [];
 
         if (isset($options["statestorage"])) {
-            $storageType = $options["statestorage"]["type"];
-            $storageOptions = $options["statestorage"];
+            $userStorageType = $options["statestorage"]["type"];
+            $userStorageOptions = $options["statestorage"];
         }
 
         return new TiqrService(
             new Tiqr_Service($options),
-            Tiqr_StateStorage::getStorage($storageType, $storageOptions),
+            Tiqr_StateStorage::getStorage($userStorageType, $userStorageOptions),
             $this->session,
             $this->logger,
             $options['name']
@@ -72,8 +72,15 @@ class TiqrFactory
     {
         $this->loadDependencies();
         $options = $this->configuration->getTiqrOptions();
-        $userStorage = Tiqr_UserStorage::getStorage($options['userstorage']['type'], $options['userstorage']);
-        return new TiqrUserRepository($userStorage);
+        $userStorage = Tiqr_UserStorage::getStorage(
+            $options['userstorage']['type'],
+            $options['userstorage']
+        );
+        $userSecretStorage = Tiqr_UserStorage::getStorage(
+            $options['usersecretstorage']['type'],
+            $options['usersecretstorage']
+        );
+        return new TiqrUserRepository($userStorage, $userSecretStorage);
     }
 
     private function loadDependencies()


### PR DESCRIPTION
This was previously done in a faulty manner. Where the `usersecretstorage` was stored in the 'regular' `userstorage`.