### PR TITLE
Catch the tiqr-server-libphp ReadWriteExceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "symfony/validator": "^4.3",
     "symfony/webpack-encore-bundle": "^1.6",
     "symfony/yaml": "^4.3",
-    "tiqr/tiqr-server-libphp": "dev-feature/state-storage-improvements"
+    "tiqr/tiqr-server-libphp": "dev-feature/exception-throwing"
   },
   "require-dev": {
     "behat/mink": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec5915cb87e1677108ad913fa026fe90",
+    "content-hash": "e5c2f9e030e46812f3c9f8f353e21210",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -38,12 +38,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Assert\\": "lib/Assert"
-                },
                 "files": [
                     "lib/Assert/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1188,21 +1188,18 @@
                     "Surfnet\\SamlBundle\\": "src"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
             "description": "A Symfony 4 bundle that integrates the simplesamlphp\\saml2 library with Symfony.",
             "keywords": [
-                "SAML",
                 "SAML2",
-                "StepUp",
+                "saml",
                 "simplesamlphp",
+                "stepup",
                 "surfnet"
             ],
-            "support": {
-                "source": "https://github.com/OpenConext/Stepup-saml-bundle/tree/4.3.2",
-                "issues": "https://github.com/OpenConext/Stepup-saml-bundle/issues"
-            },
             "time": "2021-11-23T10:22:55+00:00"
         },
         {
@@ -2794,14 +2791,14 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
                 "psr-4": {
                     "Symfony\\Component\\Intl\\": ""
                 },
                 "classmap": [
                     "Resources/stubs"
-                ],
-                "files": [
-                    "Resources/functions.php"
                 ],
                 "exclude-from-classmap": [
                     "/Tests/"
@@ -3188,12 +3185,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3268,12 +3265,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3350,12 +3347,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -3508,12 +3505,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3581,12 +3578,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -3657,12 +3654,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -3737,12 +3734,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -4527,12 +4524,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -5397,16 +5394,16 @@
         },
         {
             "name": "tiqr/tiqr-server-libphp",
-            "version": "dev-feature/state-storage-improvements",
+            "version": "dev-feature/exception-throwing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/tiqr-server-libphp.git",
-                "reference": "dbbfcdb7a63ab0d20415662c959437ab501a37a7"
+                "reference": "2f1116763ac6ca907599a371fd699bb8f0e91883"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/tiqr-server-libphp/zipball/dbbfcdb7a63ab0d20415662c959437ab501a37a7",
-                "reference": "dbbfcdb7a63ab0d20415662c959437ab501a37a7",
+                "url": "https://api.github.com/repos/SURFnet/tiqr-server-libphp/zipball/2f1116763ac6ca907599a371fd699bb8f0e91883",
+                "reference": "2f1116763ac6ca907599a371fd699bb8f0e91883",
                 "shasum": ""
             },
             "require": {
@@ -5448,10 +5445,10 @@
             ],
             "description": "php library for tiqr authentication.",
             "support": {
-                "source": "https://github.com/SURFnet/tiqr-server-libphp/tree/feature/state-storage-improvements",
+                "source": "https://github.com/SURFnet/tiqr-server-libphp/tree/feature/exception-throwing",
                 "issues": "https://github.com/SURFnet/tiqr-server-libphp/issues"
             },
-            "time": "2022-04-07T13:05:13+00:00"
+            "time": "2022-04-12T11:14:05+00:00"
         },
         {
             "name": "twig/twig",
@@ -6856,12 +6853,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/src/Exception/TiqrServerRuntimeException.php
+++ b/src/Exception/TiqrServerRuntimeException.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\Exception;
+
+use Exception;
+use RuntimeException;
+
+class TiqrServerRuntimeException extends RuntimeException
+{
+    public static function fromOriginalException(Exception $e)
+    {
+        return new self($e->getMessage());
+    }
+}

--- a/src/Features/registration.feature
+++ b/src/Features/registration.feature
@@ -68,7 +68,6 @@ Feature: When an user needs to register for a new token
       | notice | Unable to retrieve the state storage value, file not found | present |
       | info   | Start validating enrollment secret                                                                                            | present |
       | info   | Finalizing enrollment                                                                                                         | present |
-      | error | Unable to unlink the value from state storage, key not found on filesystem | present |
       | info   | Enrollment finalized                                                                                                          | present |
 
       # Tiqr page, finalized return to SP.
@@ -145,7 +144,6 @@ Feature: When an user needs to register for a new token
       | notice | Unable to retrieve the state storage value, file not found | present |
       | info   | Start validating enrollment secret                                                                                            | present |
       | info   | Finalizing enrollment                                                                                                         | present |
-      | error | Unable to unlink the value from state storage, key not found on filesystem | present |
       | info   | Enrollment finalized                                                                                                          | present |
 
       # Tiqr page, finalized return to SP.

--- a/src/Tiqr/Legacy/TiqrService.php
+++ b/src/Tiqr/Legacy/TiqrService.php
@@ -17,6 +17,7 @@
 
 namespace App\Tiqr\Legacy;
 
+use App\Exception\TiqrServerRuntimeException;
 use App\Tiqr\Response\AuthenticationErrorResponse;
 use App\Tiqr\Response\AuthenticationResponse;
 use App\Tiqr\Response\RejectedAuthenticationResponse;
@@ -24,6 +25,7 @@ use App\Tiqr\Response\ValidAuthenticationResponse;
 use App\Tiqr\TiqrServiceInterface;
 use App\Tiqr\TiqrUserInterface;
 use Psr\Log\LoggerInterface;
+use ReadWriteException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tiqr_Service;
@@ -75,7 +77,12 @@ final class TiqrService implements TiqrServiceInterface
 
     public function getEnrollmentSecret($key)
     {
-        return $this->tiqrService->getEnrollmentSecret($key);
+        try {
+            return $this->tiqrService->getEnrollmentSecret($key);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 
     /**
@@ -93,12 +100,18 @@ final class TiqrService implements TiqrServiceInterface
         $this->session->set('userId', $userId);
         $sessionId = $this->session->getId();
         $this->logger->debug('Clearing the previous enrollment state(s)');
-        $this->clearPreviousEnrollmentState();
-        $this->logger->debug('Starting the new enrollment session');
-        $enrollmentKey = $this->tiqrService->startEnrollmentSession($userId, $this->accountName, $sessionId);
-        $this->logger->debug('Storing the enrollemnt key for future reference');
-        $this->storeEnrollmentKey($enrollmentKey);
-        $this->setSariForSessionIdentifier($enrollmentKey, $sari);
+
+        try {
+            $this->clearPreviousEnrollmentState();
+            $this->logger->debug('Starting the new enrollment session');
+            $enrollmentKey = $this->tiqrService->startEnrollmentSession($userId, $this->accountName, $sessionId);
+            $this->logger->debug('Storing the enrollemnt key for future reference');
+            $this->storeEnrollmentKey($enrollmentKey);
+            $this->setSariForSessionIdentifier($enrollmentKey, $sari);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
         $this->logger->debug('Returning the new enrollment key');
         return $enrollmentKey;
     }
@@ -130,9 +143,14 @@ final class TiqrService implements TiqrServiceInterface
         }
         $format = "Removing %d keys from the enrollment session states";
         $this->logger->debug(sprintf($format, count($keys)));
-        foreach ($keys as $key) {
-            $this->tiqrService->clearEnrollmentState($key);
-            unset($keys[$key]);
+        try {
+            foreach ($keys as $key) {
+                $this->tiqrService->clearEnrollmentState($key);
+                unset($keys[$key]);
+            }
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
         }
         $format = "Reset enroll session keys, remaining keys: %d";
         $this->logger->debug(sprintf($format, count($keys)));
@@ -147,26 +165,46 @@ final class TiqrService implements TiqrServiceInterface
 
     public function getEnrollmentMetadata($key, $loginUri, $enrollmentUrl)
     {
-        return $this->tiqrService->getEnrollmentMetadata($key, $loginUri, $enrollmentUrl);
+        try {
+            return $this->tiqrService->getEnrollmentMetadata($key, $loginUri, $enrollmentUrl);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 
     public function validateEnrollmentSecret($enrollmentSecret)
     {
-        return $this->tiqrService->validateEnrollmentSecret($enrollmentSecret);
+        try {
+            return $this->tiqrService->validateEnrollmentSecret($enrollmentSecret);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 
     public function finalizeEnrollment($enrollmentSecret)
     {
-        $this->tiqrService->finalizeEnrollment($enrollmentSecret);
-        $this->unsetSariForSessionIdentifier($enrollmentSecret);
+        try {
+            $this->tiqrService->finalizeEnrollment($enrollmentSecret);
+            $this->unsetSariForSessionIdentifier($enrollmentSecret);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to  exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 
     public function startAuthentication($nameId, $sari)
     {
-        $sessionKey = $this->tiqrService->startAuthenticationSession($nameId, $this->session->getId());
-        $this->session->set('sessionKey', $sessionKey);
+        try {
+            $sessionKey = $this->tiqrService->startAuthenticationSession($nameId, $this->session->getId());
+            $this->session->set('sessionKey', $sessionKey);
 
-        $this->setSariForSessionIdentifier($sessionKey, $sari);
+            $this->setSariForSessionIdentifier($sessionKey, $sari);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to  exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
 
         return $this->tiqrService->generateAuthURL($sessionKey);
     }
@@ -216,22 +254,27 @@ final class TiqrService implements TiqrServiceInterface
      */
     public function authenticate(TiqrUserInterface $user, $response, $sessionKey)
     {
-        $result = $this->tiqrService->authenticate($user->getId(), $user->getSecret(), $sessionKey, $response);
-        switch ($result) {
-            case Tiqr_Service::AUTH_RESULT_AUTHENTICATED:
-                $this->unsetSariForSessionIdentifier($sessionKey);
+        try {
+            $result = $this->tiqrService->authenticate($user->getId(), $user->getSecret(), $sessionKey, $response);
+            switch ($result) {
+                case Tiqr_Service::AUTH_RESULT_AUTHENTICATED:
+                    $this->unsetSariForSessionIdentifier($sessionKey);
 
-                return new ValidAuthenticationResponse('OK');
-            case Tiqr_Service::AUTH_RESULT_INVALID_CHALLENGE:
-                return new AuthenticationErrorResponse('INVALID_CHALLENGE');
-            case Tiqr_Service::AUTH_RESULT_INVALID_REQUEST:
-                return new AuthenticationErrorResponse('INVALID_REQUEST');
-            case Tiqr_Service::AUTH_RESULT_INVALID_RESPONSE:
-                return new RejectedAuthenticationResponse('INVALID_RESPONSE');
-            case Tiqr_Service::AUTH_RESULT_INVALID_USERID:
-                return new AuthenticationErrorResponse('INVALID_USER');
-            default:
-                return new AuthenticationErrorResponse('ERROR');
+                    return new ValidAuthenticationResponse('OK');
+                case Tiqr_Service::AUTH_RESULT_INVALID_CHALLENGE:
+                    return new AuthenticationErrorResponse('INVALID_CHALLENGE');
+                case Tiqr_Service::AUTH_RESULT_INVALID_REQUEST:
+                    return new AuthenticationErrorResponse('INVALID_REQUEST');
+                case Tiqr_Service::AUTH_RESULT_INVALID_RESPONSE:
+                    return new RejectedAuthenticationResponse('INVALID_RESPONSE');
+                case Tiqr_Service::AUTH_RESULT_INVALID_USERID:
+                    return new AuthenticationErrorResponse('INVALID_USER');
+                default:
+                    return new AuthenticationErrorResponse('ERROR');
+            }
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to  exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
         }
     }
 
@@ -318,7 +361,12 @@ final class TiqrService implements TiqrServiceInterface
      */
     private function unsetSariForSessionIdentifier($identifier)
     {
-        $this->tiqrStateStorage->unsetValue('sari_' . $identifier);
+        try {
+            $this->tiqrStateStorage->unsetValue('sari_' . $identifier);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to  exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 
     /**
@@ -327,6 +375,11 @@ final class TiqrService implements TiqrServiceInterface
      */
     private function setSariForSessionIdentifier($identifier, $sari)
     {
-        $this->tiqrStateStorage->setValue('sari_' . $identifier, $sari);
+        try {
+            $this->tiqrStateStorage->setValue('sari_' . $identifier, $sari);
+        } catch (ReadWriteException $e) {
+            // Catch errors from the tiqr-server and up-cycle them to  exceptions that are meaningful to our domain
+            throw TiqrServerRuntimeException::fromOriginalException($e);
+        }
     }
 }


### PR DESCRIPTION
The read write exceptions are catched in the code calling the library. The exceptions are explicitly translated to an exception of our own making. Mainly for decoupling reasons.

The application does not pay further attention to these situations. As in, it will produce a 500 error when any of these situations arise. No custom user facing error reports have been prioritized for now.

See: https://www.pivotaltracker.com/story/show/181553909
The biggest win for now is that the application does not continue execution after a critical point failed previously.