### PR TITLE
Raise log level for invalid secret

### DIFF
--- a/src/Controller/TiqrAppApiController.php
+++ b/src/Controller/TiqrAppApiController.php
@@ -171,7 +171,7 @@ class TiqrAppApiController extends AbstractController
         $userId = $this->tiqrService->validateEnrollmentSecret($enrollmentSecret);
 
         if ($userId === false) {
-            $logger->info('Invalid enrollment secret');
+            $logger->error('Invalid enrollment secret');
 
             return new Response('Enrollment failed', Response::HTTP_FORBIDDEN);
         }
@@ -230,7 +230,7 @@ class TiqrAppApiController extends AbstractController
             return new Response($result->getMessage(), Response::HTTP_OK);
         }
 
-        $logger->info('User denied authenticated ' . $result->getMessage());
+        $logger->info('User denied ' . $result->getMessage());
 
         return new Response($result->getMessage(), Response::HTTP_FORBIDDEN);
     }


### PR DESCRIPTION
An invalid secret should never happen during a normal use-case, so this should be logged as an error.
I could live with `warning` as well, but `info` just doesn't fit here.