### PR TITLE
Fix missing translation

### DIFF
--- a/translations/error/messages.en.yml
+++ b/translations/error/messages.en.yml
@@ -30,5 +30,7 @@ page.route.description.sp_demo: |
   Demo service provider to test the tiqr application with.
   This is not part of the tiqr application and can only be used in development (app_dev.php) mode.
 
-
 stepup.error.unknown_service_provider.title: Unknown service provider
+
+stepup.error.signature_validation_failed.title: Invalid signature
+stepup.error.signature_validation_failed.description: Invalid signature

--- a/translations/error/messages.nl.yml
+++ b/translations/error/messages.nl.yml
@@ -31,3 +31,6 @@ page.route.description.sp_demo: |
   Dit is geen onderdeel van de tiqr-applicatie en kan alleen worden gebruikt in de ontwikkelingsmodus (app_dev.php).
 
 stepup.error.unknown_service_provider.title: Onbekende serviceprovider
+
+stepup.error.signature_validation_failed.title: Ongeldige handtekening
+stepup.error.signature_validation_failed.description: Ongeldige handtekening


### PR DESCRIPTION
Fixes:

![afbeelding](https://user-images.githubusercontent.com/841045/202804132-ff3b1321-eab3-45b1-b3c8-fbd46d11ac85.png)

Since this error is triggered by the stepup-bundle, I wonder if this translation has to be added to other gssf's as well? I noticed webauthn doesn't have this tag as well..