### PR TITLE
Run cache:clear on composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,12 @@
       "yarn install --frozen-lockfile",
       "yarn encore production"
     ],
+    "post-install-cmd": [
+        "@auto-scripts"
+    ],
+    "post-update-cmd": [
+        "@auto-scripts"
+    ],
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
       "assets:install %PUBLIC_DIR%": "symfony-cmd"


### PR DESCRIPTION
Run scripts on composer install/update, just like all the other modules in the stepup-suite.