### PR TITLE
Fix OTP form rendering classes

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -148,6 +148,7 @@ div.middle {
 #otpform {
   width: 50%;
   margin: 0 auto;
+  margin-top: 1em;
   display: block;
   float: none;
 

--- a/templates/default/authentication.html.twig
+++ b/templates/default/authentication.html.twig
@@ -64,10 +64,10 @@
 
     <div id="otpform">
         <form method="POST" class="form-inline">
-            <div class="input-group">
-                <input type="text" name="otp" tabindex="3"
+            <div class="form-group">
+                <input type="text" name="otp" tabindex="3" class="form-control"
                        placeholder="{{ 'login.qr.manual.otp' | trans }}"
-                       autocomplete="off" />
+                       autocomplete="off">
                 &nbsp;
                 <button type="submit" class="btn btn-primary">{{ 'login.qr.manual.button' | trans }}</button>
             </div>


### PR DESCRIPTION
The form was not using the correct bootstrap form classes so was ugly

Before:
<img width="618" alt="afbeelding" src="https://github.com/OpenConext/Stepup-tiqr/assets/3808792/412444f6-0a59-4870-9fa1-4f8284f12f77">
After:
<img width="601" alt="afbeelding" src="https://github.com/OpenConext/Stepup-tiqr/assets/3808792/9391128a-6dda-48f8-babc-eab9b32d80ac">
