### PR TITLE
Allow no notification address or type

### DIFF
--- a/dev/Command/AuthenticationCommand.php
+++ b/dev/Command/AuthenticationCommand.php
@@ -143,8 +143,8 @@ class AuthenticationCommand extends Command
             'sessionKey' => $session,
             'userId' => $userId,
             'response' => $response,
-            'notificationType' => $input->getOption('notificationType'),
-            'notificationAddress' => $input->getOption('notificationAddress'),
+            'notificationType' => $input->getOption('notificationType', ''),
+            'notificationAddress' => $input->getOption('notificationAddress', ''),
         ];
 
         $output->writeln([

--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -328,20 +328,23 @@ class AuthenticationController extends AbstractController
         // Send notification.
         $notificationType = $user->getNotificationType();
         $notificationAddress = $user->getNotificationAddress();
-        $this->logger->notice(sprintf(
-            'Sending push notification for user "%s" with type "%s" and (untranslated) address "%s"',
-            $nameId,
-            $notificationType,
-            $notificationAddress
-        ));
 
         if ($notificationType && $notificationAddress) {
+            $this->logger->notice(sprintf(
+                'Sending push notification for user "%s" with type "%s" and (untranslated) address "%s"',
+                $nameId,
+                $notificationType,
+                $notificationAddress
+            ));
+
             $result = $this->sendNotification($notificationType, $notificationAddress);
             if ($result) {
                 return $this->generateNotificationResponse('success');
             }
             return $this->generateNotificationResponse('error');
         }
+
+        $this->logger->notice(sprintf('No notification address for user "%s", no notification was sent', $nameId));
 
         return $this->generateNotificationResponse('no-device');
     }

--- a/src/Controller/TiqrAppApiController.php
+++ b/src/Controller/TiqrAppApiController.php
@@ -115,8 +115,8 @@ class TiqrAppApiController extends AbstractController
             return new Response('Missing "operation" parameter in POST', Response::HTTP_BAD_REQUEST);
         }
 
-        $notificationType = $request->get('notificationType');
-        $notificationAddress = $request->get('notificationAddress');
+        $notificationType = $request->get('notificationType', '');
+        $notificationAddress = $request->get('notificationAddress', '');
         if ($operation === 'register') {
             $this->logger->notice(
                 'Got POST with registration response',

--- a/src/Features/Context/TiqrContext.php
+++ b/src/Features/Context/TiqrContext.php
@@ -173,6 +173,12 @@ class TiqrContext implements Context
             'notificationType' => $notificationType,
             'notificationAddress' => $notificationAddress,
         ];
+        if ($notificationType == 'NULL') {
+            unset($registrationBody['notificationType']);
+        }
+        if ($notificationAddress == 'NULL') {
+            unset($registrationBody['notificationAddress']);
+        }
 
         $client = $this->minkContext->getSession()->getDriver()->getClient();
         $client->request(
@@ -221,6 +227,12 @@ class TiqrContext implements Context
             'notificationType' => $notificationType,
             'notificationAddress' => $notificationAddress,
         ];
+        if ($notificationType == 'NULL') {
+            unset($authenticationBody['notificationType']);
+        }
+        if ($notificationAddress == 'NULL') {
+            unset($authenticationBody['notificationAddress']);
+        }
         // Internal request does not like an absolute path.
         $authenticationUrl = str_replace('https://tiqr.dev.openconext.local', '', (string) $authenticationUrl);
 

--- a/src/Features/tiqrAuthentication.feature
+++ b/src/Features/tiqrAuthentication.feature
@@ -60,3 +60,8 @@ Feature: User
     # Try it with the actual correct password
     And the app authenticates to the service
     Then we have the authentication error 'ACCOUNT_BLOCKED'
+
+  Scenario: The app authenticats whithout updating notification address
+    Given the authentication QR code is scanned
+    When the app authenticates to the service with notification type "NULL" address: "NULL"
+    Then we have a authenticated user

--- a/src/Features/tiqrRegistration.feature
+++ b/src/Features/tiqrRegistration.feature
@@ -18,3 +18,8 @@ Feature: User
     And the mobile tiqr app identifies itself with the user agent "Bad UA"
     When the user registers the service
     Then tiqr errors with a message telling the user agent was wrong
+
+  Scenario: Registration without notification type and address is allowed
+    Given the registration QR code is scanned
+    When the user registers the service with notification type "NULL" address: "NULL"
+    Then we have a registered user

--- a/src/Tiqr/Legacy/TiqrUser.php
+++ b/src/Tiqr/Legacy/TiqrUser.php
@@ -224,7 +224,15 @@ class TiqrUser implements TiqrUserInterface
     public function getNotificationAddress(): string
     {
         try {
-            return $this->userStorage->getNotificationAddress($this->userId);
+            $notificationAddress=$this->userStorage->getNotificationAddress($this->userId);
+
+            // Filter bogus "null" and "(null)" entries that were put in the database by returning '' instead.
+            // There is no point in trying to send a notification to such addresses.
+            $notificationAddressLower = strtolower($notificationAddress);
+            if (($notificationAddressLower == 'null') || ($notificationAddressLower == '(null)')) {
+                return '';
+            }
+            return $notificationAddress;
         } catch (Exception $e) {
             throw TiqrServerRuntimeException::fromOriginalException($e);
         }


### PR DESCRIPTION
Normally a client sends the notificationAddress and notificationType parameters with each registration and authentication response as HTTP POST parameters. In some situations however a tiqr client can not get a notification address. Different clients respond (and have responded) differently to this situation. The notificationAddress and notificationType parameters may be absent, or both or only notificationAddress maybe set to the string "(null)" or "NULL". This leads to several issues that this PR addresses:
* Currently there are user entries in the user storage table that have notificationAddress set to '(null)' or 'NULL'. Stepup-tiqr tries to send a push notification to these addresses, and that leads to an error. We change this behaviour so that NULL or (null) means no push address / type so no notification is send. We explicitly log this situation.

* When a client omits a notificationAddress or notificationType this currently leads to an exception and the registration will fail. We change this behaviour so that this is accepted and allow the registration and authentication to continue.
