### PR TITLE
Fixed reading the QR code as text in the AuthenticationCommand on dev environments

### DIFF
--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -1,6 +1,236 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Cannot access offset 'authenticationUrl' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset 'identities' on mixed\\.$#"
+			count: 2
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset 'ocraSuite' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset 'secret' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset string on mixed\\.$#"
+			count: 2
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Comparison operation \"\\>\\=\" between int\\<0, max\\>\\|false and 0 is always true\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\AuthenticationCommand\\:\\:decorateResult\\(\\) has parameter \\$text with no type specified\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Method Symfony\\\\Component\\\\Console\\\\Input\\\\InputInterface\\:\\:getOption\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 2
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\AuthenticationCommand\\:\\:readAuthenticationLinkFromFile\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$ocraSuite of static method OCRA\\:\\:generateOCRA\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$uri of method GuzzleHttp\\\\Client\\:\\:post\\(\\) expects Psr\\\\Http\\\\Message\\\\UriInterface\\|string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$key of static method OCRA\\:\\:generateOCRA\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
+			message: "#^Cannot access offset 'authenticationUrl' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Cannot access offset 'identities' on mixed\\.$#"
+			count: 2
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Cannot access offset 'ocraSuite' on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 5
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Cannot access property \\$service on mixed\\.$#"
+			count: 2
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\RegistrationCommand\\:\\:decorateResult\\(\\) has parameter \\$text with no type specified\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\RegistrationCommand\\:\\:storeIdentity\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\RegistrationCommand\\:\\:storeIdentity\\(\\) has parameter \\$secret with no type specified\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\RegistrationCommand\\:\\:readRegistrationUrlFromFile\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../dev/Command/RegistrationCommand.php
+
+		-
+			message: "#^Call to an undefined method SAML2\\\\Message\\:\\:getStatus\\(\\)\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Cannot call method getValue\\(\\) on SAML2\\\\XML\\\\saml\\\\Issuer\\|null\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Controller\\\\SPController\\:\\:signRequestQuery\\(\\) has parameter \\$queryParams with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$securityKey\\)\\: Unexpected token \"\\$securityKey\", expected type at offset 10$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of method SAML2\\\\Certificate\\\\PrivateKeyLoader\\:\\:loadPrivateKey\\(\\) expects SAML2\\\\Configuration\\\\PrivateKey, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$nameId of method Surfnet\\\\SamlBundle\\\\SAML2\\\\AuthnRequest\\:\\:setSubject\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$source of method DOMDocument\\:\\:loadXML\\(\\) expects string, bool\\|string given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_decode expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#1 \\$xml of static method SAML2\\\\Message\\:\\:fromXML\\(\\) expects DOMElement, DOMElement\\|null given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Parameter \\#2 \\$values of method Symfony\\\\Component\\\\HttpFoundation\\\\ResponseHeaderBag\\:\\:set\\(\\) expects array\\<string\\>\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: ../../dev/Controller/SPController.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\FileLogger\\:\\:getLogs\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../dev/FileLogger.php
+
+		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\FileLogger\\:\\:log\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../dev/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$record of method League\\\\Csv\\\\Writer\\:\\:insertOne\\(\\) expects array\\<float\\|int\\|string\\|Stringable\\|null\\>, array\\<int, mixed\\> given\\.$#"
+			count: 1
+			path: ../../dev/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: ../../dev/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of static method League\\\\Csv\\\\AbstractCsv\\:\\:createFromStream\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: ../../dev/FileLogger.php
+
+		-
+			message: "#^Cannot call method getEntityId\\(\\) on Surfnet\\\\SamlBundle\\\\Entity\\\\IdentityProvider\\|null\\.$#"
+			count: 1
+			path: ../../dev/Twig/GsspExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|null given\\.$#"
+			count: 1
+			path: ../../dev/Twig/GsspExtension.php
+
+		-
 			message: "#^Parameter \\#3 \\$response of method Surfnet\\\\Tiqr\\\\Tiqr\\\\AuthenticationRateLimitServiceInterface\\:\\:authenticate\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: ../../src/Controller/AuthenticationController.php

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -41,6 +41,11 @@ parameters:
 			path: ../../dev/Command/AuthenticationCommand.php
 
 		-
+			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\AuthenticationCommand\\:\\:readAuthenticationLinkFromFile\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
 			message: "#^Method Symfony\\\\Component\\\\Console\\\\Input\\\\InputInterface\\:\\:getOption\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 2
 			path: ../../dev/Command/AuthenticationCommand.php

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -26,28 +26,13 @@ parameters:
 			path: ../../dev/Command/AuthenticationCommand.php
 
 		-
+			message: "#^Cannot access offset int\\|string\\|false on mixed\\.$#"
+			count: 1
+			path: ../../dev/Command/AuthenticationCommand.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 2
-			path: ../../dev/Command/AuthenticationCommand.php
-
-		-
-			message: "#^Comparison operation \"\\>\\=\" between int\\<0, max\\>\\|false and 0 is always true\\.$#"
 			count: 1
-			path: ../../dev/Command/AuthenticationCommand.php
-
-		-
-			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\AuthenticationCommand\\:\\:decorateResult\\(\\) has parameter \\$text with no type specified\\.$#"
-			count: 1
-			path: ../../dev/Command/AuthenticationCommand.php
-
-		-
-			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\AuthenticationCommand\\:\\:readAuthenticationLinkFromFile\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: ../../dev/Command/AuthenticationCommand.php
-
-		-
-			message: "#^Method Symfony\\\\Component\\\\Console\\\\Input\\\\InputInterface\\:\\:getOption\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 2
 			path: ../../dev/Command/AuthenticationCommand.php
 
 		-
@@ -86,11 +71,6 @@ parameters:
 			path: ../../dev/Command/AuthenticationCommand.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 1
-			path: ../../dev/Command/AuthenticationCommand.php
-
-		-
 			message: "#^Cannot access offset 'authenticationUrl' on mixed\\.$#"
 			count: 1
 			path: ../../dev/Command/RegistrationCommand.php
@@ -113,11 +93,6 @@ parameters:
 		-
 			message: "#^Cannot access property \\$service on mixed\\.$#"
 			count: 2
-			path: ../../dev/Command/RegistrationCommand.php
-
-		-
-			message: "#^Method Surfnet\\\\Tiqr\\\\Dev\\\\Command\\\\RegistrationCommand\\:\\:decorateResult\\(\\) has parameter \\$text with no type specified\\.$#"
-			count: 1
 			path: ../../dev/Command/RegistrationCommand.php
 
 		-
@@ -216,24 +191,9 @@ parameters:
 			path: ../../dev/FileLogger.php
 
 		-
-			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: ../../dev/FileLogger.php
-
-		-
 			message: "#^Parameter \\#1 \\$stream of static method League\\\\Csv\\\\AbstractCsv\\:\\:createFromStream\\(\\) expects resource, resource\\|false given\\.$#"
-			count: 2
+			count: 1
 			path: ../../dev/FileLogger.php
-
-		-
-			message: "#^Cannot call method getEntityId\\(\\) on Surfnet\\\\SamlBundle\\\\Entity\\\\IdentityProvider\\|null\\.$#"
-			count: 1
-			path: ../../dev/Twig/GsspExtension.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|null given\\.$#"
-			count: 1
-			path: ../../dev/Twig/GsspExtension.php
 
 		-
 			message: "#^Parameter \\#3 \\$response of method Surfnet\\\\Tiqr\\\\Tiqr\\\\AuthenticationRateLimitServiceInterface\\:\\:authenticate\\(\\) expects string, mixed given\\.$#"

--- a/ci/qa/phpstan.neon
+++ b/ci/qa/phpstan.neon
@@ -5,3 +5,4 @@ parameters:
 	level: 9
 	paths:
 		- ../../src
+		- ../../dev

--- a/dev/Command/AuthenticationCommand.php
+++ b/dev/Command/AuthenticationCommand.php
@@ -88,7 +88,7 @@ class AuthenticationCommand extends Command
         [$serviceId, $session, $challenge, $sp, $version] = explode('/', $authn);
 
         $userId = null;
-        if (strpos($serviceId, '@') >= 0) {
+        if (str_contains($serviceId, '@')) {
             [$userId, $serviceId] = explode('@', $serviceId);
         }
 
@@ -101,7 +101,7 @@ class AuthenticationCommand extends Command
                 'sp' => $sp,
                 'version' => $version,
                 'userId' => $userId,
-            ], JSON_PRETTY_PRINT)),
+            ], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)),
         ]);
 
         $service = $this->getService($serviceId);
@@ -126,7 +126,7 @@ class AuthenticationCommand extends Command
         $service['id'] = $serviceId;
         $output->writeln([
             '<comment>Generate OCRA for service:</comment>',
-            $this->decorateResult(json_encode($service, JSON_PRETTY_PRINT)),
+            $this->decorateResult(json_encode($service, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)),
         ]);
 
         $response = OCRA::generateOCRA($ocraSuite, $secret, '', $challenge, '', $session, '');
@@ -143,8 +143,8 @@ class AuthenticationCommand extends Command
             'sessionKey' => $session,
             'userId' => $userId,
             'response' => $response,
-            'notificationType' => $input->getOption('notificationType', ''),
-            'notificationAddress' => $input->getOption('notificationAddress', ''),
+            'notificationType' => $input->getOption('notificationType'),
+            'notificationAddress' => $input->getOption('notificationAddress'),
         ];
 
         $output->writeln([
@@ -152,7 +152,7 @@ class AuthenticationCommand extends Command
                 '<comment>Send authentication data to "%s" with body:</comment>',
                 $authenticationUrl
             ),
-            $this->decorateResult(json_encode($authenticationBody, JSON_PRETTY_PRINT)),
+            $this->decorateResult(json_encode($authenticationBody, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)),
         ]);
 
         $result = $this->client->post($authenticationUrl, [
@@ -166,7 +166,7 @@ class AuthenticationCommand extends Command
         return Command::SUCCESS;
     }
 
-    protected function decorateResult($text): string
+    protected function decorateResult(string $text): string
     {
         return "<options=bold>$text</>";
     }
@@ -176,6 +176,10 @@ class AuthenticationCommand extends Command
         $qrcode = new QrReader(file_get_contents($file), QrReader::SOURCE_TYPE_BLOB);
         /** @phpstan-var mixed $link */
         $link = $qrcode->text();
+
+        if (!is_string($link)) {
+            throw new RuntimeException('Unable to read a link from the QR code');
+        }
 
         $output->writeln([
             'Registration link result: ',

--- a/dev/Command/AuthenticationCommand.php
+++ b/dev/Command/AuthenticationCommand.php
@@ -174,6 +174,7 @@ class AuthenticationCommand extends Command
     protected function readAuthenticationLinkFromFile(string $file, OutputInterface $output): string
     {
         $qrcode = new QrReader(file_get_contents($file), QrReader::SOURCE_TYPE_BLOB);
+        /** @phpstan-var mixed $link */
         $link = $qrcode->text();
 
         $output->writeln([
@@ -181,7 +182,7 @@ class AuthenticationCommand extends Command
             $this->decorateResult($link),
         ]);
 
-        return $link->toString();
+        return $link;
     }
 
     /**

--- a/dev/Command/RegistrationCommand.php
+++ b/dev/Command/RegistrationCommand.php
@@ -78,7 +78,7 @@ class RegistrationCommand extends Command
         $metadata = json_decode($metadataBody);
         $output->writeln([
             'Metadata result:',
-            $this->decorateResult(json_encode($metadata, JSON_PRETTY_PRINT)),
+            $this->decorateResult(json_encode($metadata, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)),
         ]);
         if ($metadata === false) {
             $output->writeln('<error>Metadata has expired</error>');
@@ -99,7 +99,7 @@ class RegistrationCommand extends Command
                 '<comment>Send registration data to enrollmentUrl "%s" with body:</comment>',
                 $metadata->service->enrollmentUrl
             ),
-            $this->decorateResult(json_encode($registrationBody, JSON_PRETTY_PRINT)),
+            $this->decorateResult(json_encode($registrationBody, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR)),
         ]);
 
         $result = $this->client->post($metadata->service->enrollmentUrl, ['form_params' => $registrationBody]);
@@ -121,7 +121,7 @@ class RegistrationCommand extends Command
         return Command::SUCCESS;
     }
 
-    protected function decorateResult($text): string
+    protected function decorateResult(string $text): string
     {
         return "<options=bold>$text</>";
     }

--- a/dev/FileLogger.php
+++ b/dev/FileLogger.php
@@ -36,6 +36,10 @@ final class FileLogger extends AbstractLogger
             return;
         }
         $file = fopen($this->getCSVFile(), 'ab+');
+        if (!$file) {
+            return;
+        }
+
         $csv = Writer::createFromStream($file);
         $csv->setDelimiter(';');
         $csv->insertOne([$level, $message, json_encode($context)]);

--- a/dev/Twig/GsspExtension.php
+++ b/dev/Twig/GsspExtension.php
@@ -38,7 +38,7 @@ final class GsspExtension extends AbstractExtension
     {
         return sprintf(
             'https://pieter.aai.surfnet.nl/simplesamlphp/sp.php?idp=%s',
-            urlencode($this->hostedEntities->getIdentityProvider()->getEntityId())
+            urlencode($this->hostedEntities->getIdentityProvider()?->getEntityId() ?? '')
         );
     }
 }


### PR DESCRIPTION
The Authentication command wasn't able to read the QR code as text because it would try to convert to a string twice.
Also added PHPStan for all dev code and improved some other reported problems, improving code quality.