### PR TITLE
Improve timeouts during registration/authentication polling

### DIFF
--- a/assets/typescript/Component/RegistrationStatusComponent.ts
+++ b/assets/typescript/Component/RegistrationStatusComponent.ts
@@ -49,6 +49,12 @@ export class RegistrationStatusComponent {
   public showUnknownErrorHappened() {
     this.show('div.status.error');
   }
+  /**
+   * Unknown error happened. Please try again by refreshing your browser.
+   */
+  public showTimeoutHappened() {
+    this.show('div.status.timeout');
+  }
 
   private hideAll() {
     jQuery('.status-container >').hide();

--- a/assets/typescript/RegistrationStateMachine.ts
+++ b/assets/typescript/RegistrationStateMachine.ts
@@ -12,6 +12,8 @@ export class RegistrationStateMachine {
    * Client-side only status.
    */
   public static readonly ERROR = 'ERROR';
+  public static readonly TIMEOUT = 'TIMEOUT';
+
   private previousStatus = RegistrationStateMachine.IDLE;
 
   constructor(private statusPollingService: StatusPollService,
@@ -61,6 +63,12 @@ export class RegistrationStateMachine {
         this.statusUi.showFinalized();
         this.qrCode.hide();
         document.location.replace(this.finalizedUrl);
+        break;
+      case RegistrationStateMachine.TIMEOUT:
+        this.qrCode.hide();
+        this.statusUi.showTimeoutHappened();
+        this.statusPollingService.stop();
+        this.previousStatus = RegistrationStateMachine.ERROR;
         break;
       default:
         this.unknownError();

--- a/assets/typescript/__test__/RegistrationPageService.test.ts
+++ b/assets/typescript/__test__/RegistrationPageService.test.ts
@@ -141,6 +141,28 @@ describe('RegistrationPageService', () => {
     });
   });
 
+  describe('When timeout', () => {
+    beforeEach(() => {
+      context.authenticationPageService.start();
+      if (!statusCallback || !errorCallback) {
+        throw new Error('Should have started status request');
+      }
+      statusCallback(RegistrationStateMachine.TIMEOUT);
+    });
+
+    it('The qr code should be hidden', () => {
+      expect(context.qrComponent.isVisible()).toBeFalsy();
+    });
+
+    it('Polling should be disabled', () => {
+      expect(context.pollingService.enabled).toBeFalsy();
+    });
+
+    it('Show finalized', () => {
+      expect(context.statusUi.showTimeoutHappened).toBeCalled();
+    });
+  });
+
   describe('When connection error occurred', () => {
     beforeEach(() => {
       context.authenticationPageService.start();
@@ -227,6 +249,7 @@ describe('RegistrationPageService', () => {
       showAccountActivationHelp:jest.fn(),
       showOneMomentPlease: jest.fn(),
       showFinalized: jest.fn(),
+      showTimeoutHappened: jest.fn(),
       showUnknownErrorHappened: jest.fn(),
     };
 

--- a/src/Controller/AuthenticationStatusController.php
+++ b/src/Controller/AuthenticationStatusController.php
@@ -57,6 +57,7 @@ class AuthenticationStatusController
                 return $this->refreshAuthenticationPage();
             }
 
+
             $isAuthenticated = $this->tiqrService->isAuthenticated();
 
             if ($isAuthenticated) {
@@ -65,7 +66,8 @@ class AuthenticationStatusController
                 return $this->refreshAuthenticationPage();
             }
 
-            if ($this->authenticationChallengeIsExpired()) {
+            if ($this->tiqrService->isAuthenticationTimedOut()) {
+                $this->logger->info('The authentication timed out');
                 return $this->timeoutNeedsManualRetry();
             }
 
@@ -109,28 +111,6 @@ class AuthenticationStatusController
     private function refreshAuthenticationPage(): JsonResponse
     {
         return $this->generateAuthenticationStatusResponse('needs-refresh');
-    }
-
-    /**
-     * Check if the authentication challenge is expired.
-     *
-     * If the challenge is expired, the page should be refreshed so a new
-     * challenge and QR code is generated.
-     *
-     * @return bool
-     */
-    private function authenticationChallengeIsExpired(): bool
-    {
-        // The use of authenticationUrl() here is a hack, because it depends on an implementation detail
-        // of this function.
-        // Effectively this does a $this->_stateStorage->getValue(self::PREFIX_CHALLENGE . $sessionKey);
-        // To check that the session key still exists in the Tiqr_Service's state storage
-        try {
-            $this->tiqrService->authenticationUrl();
-        } catch (Exception) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/src/Service/TimeoutHelper.php
+++ b/src/Service/TimeoutHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Tiqr\Service;
+
+class TimeoutHelper
+{
+    public static function isTimedOut(
+        int $currentTime,
+        int $startedAt,
+        int $timeoutInSeconds,
+        int $offset
+    ) : bool {
+        $timeoutAt = $startedAt - $offset;
+        return ($currentTime - $timeoutAt) >= $timeoutInSeconds;
+    }
+}

--- a/src/Tiqr/TiqrServiceInterface.php
+++ b/src/Tiqr/TiqrServiceInterface.php
@@ -244,4 +244,6 @@ interface TiqrServiceInterface
     public function stateStorageHealthCheck(): HealthCheckResultDto;
 
     public function isEnrollmentTimedOut(): bool;
+
+    public function isAuthenticationTimedOut(): bool;
 }

--- a/src/Tiqr/TiqrServiceInterface.php
+++ b/src/Tiqr/TiqrServiceInterface.php
@@ -242,4 +242,6 @@ interface TiqrServiceInterface
     public function getSariForSessionIdentifier(string $identifier): string;
 
     public function stateStorageHealthCheck(): HealthCheckResultDto;
+
+    public function isEnrollmentTimedOut(): bool;
 }

--- a/templates/default/registration.html.twig
+++ b/templates/default/registration.html.twig
@@ -45,6 +45,10 @@
             {{ 'enrol.status.error' | trans }}
             <a href="{{ path('app_identity_registration') }}">{{ 'enrol.retry' | trans }}</a>.
         </div>
+        <div class="status timeout">
+            {{ 'enrol.status.timeout' | trans }}
+            <a href="{{ path('app_identity_registration') }}">{{ 'enrol.retry' | trans }}</a>.
+        </div>
     </div>
     <div class="content-container qr">
         <a href="{{ metadataUrl }}">

--- a/tests/Unit/TimeoutHelperTest.php
+++ b/tests/Unit/TimeoutHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\Tiqr\Service\TimeoutHelper;
+
+class TimeoutHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideTimeoutExpectations
+     */
+    public function test_timeout_reached(
+        bool $expectation,
+        int $currentTime,
+        int $startedAt,
+        int $timeoutInSeconds,
+        int $offset
+    ): void{
+        $isTimedOut = TimeoutHelper::isTimedOut(
+            $currentTime,
+            $startedAt,
+            $timeoutInSeconds,
+            $offset,
+        );
+        self::assertEquals($expectation, $isTimedOut);
+    }
+
+    public function provideTimeoutExpectations(): array
+    {
+        return [
+            // Timed out expectations
+            'way over time' => [true, 1000, 0, 300, 2], // 100 seconds ago the user started the clock
+            'just over time' => [true, 303, 0, 300, 2], // 5 seconds over timeout time
+            'timeout due to offset - 1' => [true, 298, 0, 300, 2], // the offset is reached
+            'timeout due to offset - 2' => [true, 299, 0, 300, 2], // the offset is reached
+            // In time expectations
+            'very much in time' => [false, 0, 0, 300, 2], // 298 seconds to go before reaching timeout
+            'just in time' => [false, 297, 0, 300, 2], // last second before reaching timeout
+        ];
+    }
+}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -51,6 +51,7 @@ enrol:
         processed: One moment please...
         finalized: Your account is ready for use.
         error: Unknown error occurred. Please try again by refreshing your browser.
+        timeout: Registration timeout. Try again or refresh this page.
     download: Download tiqr for <a href="https://itunes.apple.com/us/app/tiqr/id430838214?mt=8&ls=1" target="_blank">iOS</a>/<a href="https://play.google.com/store/apps/details?id=org.tiqr.authenticator&hl=nl" target="_blank">Android</a>
     cancel: Cancel
 

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -55,6 +55,7 @@ enrol:
         processed: Een ogenblik geduld a.u.b.
         finalized: Je account is gereed voor gebruik.
         error: Er is een onbekende fout opgetreden. Probeer het opnieuw door uw browser te vernieuwen.
+        timeout: Registratie timeout. Ververs de pagina om het nogmaals te proberen.
     download: Download de tiqr-app voor <a href="https://itunes.apple.com/us/app/tiqr/id430838214?mt=8&ls=1" target="_blank">iOS</a>/<a href="https://play.google.com/store/apps/details?id=org.tiqr.authenticator&hl=nl" target="_blank">Android</a>
     cancel: Annuleren
 


### PR DESCRIPTION
While polling for authn/registration state changes. The globally defined timeout periods for these actions where not tested explicitly. This PR ensures we start testing if the timeout period is expired. 

For registration, I added a new timeout error page. For this a new translation was added @pmeulen do you agree with my proposed translations? If not feel free to suggest better ones. I based these off the authn ones.

An offset time is substracted from the hard timeout time. This makes the timeout occur a couple of seconds before the actual timeout would take place. This prevents user actions taking place right before expiration time from erroring. 

See: https://www.pivotaltracker.com/story/show/188205272 (note that the story mentions registration/authentication sessions. These are not to be confused with state/php sessions. But they are the 'session' in which an authentication or a registration takes place.)