### PR TITLE
Add the session id derived id to polling requests

### DIFF
--- a/assets/typescript/Client/StatusClient.ts
+++ b/assets/typescript/Client/StatusClient.ts
@@ -5,14 +5,18 @@ export interface PendingRequest {
 }
 
 export class StatusClient {
-  constructor(private apiUrl: string) {
-
+  constructor(
+    private apiUrl: string,
+    private correlationLoggingId: string,
+  ) {
   }
 
   /**
    * Request status form the API.
    */
   public request(callback: (status: string) => void, errorCallback: (error: unknown) => void): PendingRequest {
-    return jQuery.get(this.apiUrl, callback).fail(errorCallback);
+    const url = this.apiUrl + (this.apiUrl.includes('?') ? '&' : '?') + 'correlation-id=' + this.correlationLoggingId;
+
+    return jQuery.get(url, callback).fail(errorCallback);
   }
 }

--- a/assets/typescript/authentication.ts
+++ b/assets/typescript/authentication.ts
@@ -8,12 +8,12 @@ import jQuery from 'jquery';
 
 declare global {
   interface Window {
-    bootstrapAuthentication: (statusApiUrl: string, notificationApiUrl: string) => AuthenticationPageService;
+    bootstrapAuthentication: (statusApiUrl: string, notificationApiUrl: string, correlationLoggingId: string) => AuthenticationPageService;
   }
 }
 
-window.bootstrapAuthentication = (statusApiUrl: string, notificationApiUrl: string) => {
-  const statusClient = new StatusClient(statusApiUrl);
+window.bootstrapAuthentication = (statusApiUrl: string, notificationApiUrl: string, correlationLoggingId: string) => {
+  const statusClient = new StatusClient(statusApiUrl, correlationLoggingId);
   const notificationClient = new NotificationClient(notificationApiUrl);
   const pollingService = new StatusPollService(statusClient);
 

--- a/assets/typescript/registration.ts
+++ b/assets/typescript/registration.ts
@@ -7,12 +7,16 @@ import jQuery from 'jquery';
 
 declare global {
   interface Window {
-    bootstrapRegistration: (statusApiUrl: string, notificationApiUrl: string) => RegistrationStateMachine;
+    bootstrapRegistration: (
+      statusApiUrl: string,
+      notificationApiUrl: string,
+      correlationLoggingId: string
+    ) => RegistrationStateMachine;
   }
 }
 
-window.bootstrapRegistration = (statusApiUrl: string, finalizedUrl: string) => {
-  const statusClient = new StatusClient(statusApiUrl);
+window.bootstrapRegistration = (statusApiUrl: string, finalizedUrl: string, correlationLoggingId: string) => {
+  const statusClient = new StatusClient(statusApiUrl, correlationLoggingId);
   const pollingService = new StatusPollService(statusClient);
   const machine = new RegistrationStateMachine(
     pollingService,

--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -29,6 +29,7 @@ use Surfnet\Tiqr\Exception\NoActiveAuthenrequestException;
 use Surfnet\Tiqr\Exception\UserNotFoundException;
 use Surfnet\Tiqr\Exception\UserPermanentlyBlockedException;
 use Surfnet\Tiqr\Exception\UserTemporarilyBlockedException;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
 use Surfnet\Tiqr\Tiqr\AuthenticationRateLimitServiceInterface;
 use Surfnet\Tiqr\Tiqr\Exception\UserNotExistsException;
 use Surfnet\Tiqr\Tiqr\Response\AuthenticationResponse;
@@ -53,6 +54,7 @@ class AuthenticationController extends AbstractController
         private readonly TiqrServiceInterface $tiqrService,
         private readonly TiqrUserRepositoryInterface $userRepository,
         private readonly AuthenticationRateLimitServiceInterface $authenticationRateLimitService,
+        private readonly SessionCorrelationIdService $correlationIdService,
         private readonly LoggerInterface $logger
     ) {
     }
@@ -145,8 +147,8 @@ class AuthenticationController extends AbstractController
         $logger->info('Return authentication page with QR code');
 
         return $this->render('default/authentication.html.twig', [
-            // TODO: Add something identifying the authentication session to the authenticateUrl
-            'authenticateUrl' => $this->tiqrService->authenticationUrl()
+            'authenticateUrl' => $this->tiqrService->authenticationUrl(),
+            'correlationLoggingId' => $this->correlationIdService->generateCorrelationId(),
         ]);
     }
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -25,6 +25,7 @@ use Surfnet\GsspBundle\Service\RegistrationService;
 use Surfnet\GsspBundle\Service\StateHandlerInterface;
 use Surfnet\Tiqr\Attribute\RequiresActiveSession;
 use Surfnet\Tiqr\Exception\NoActiveAuthenrequestException;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
 use Surfnet\Tiqr\Tiqr\Legacy\TiqrService;
 use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -38,6 +39,7 @@ class RegistrationController extends AbstractController
         private readonly RegistrationService $registrationService,
         private readonly StateHandlerInterface $stateHandler,
         private readonly TiqrServiceInterface $tiqrService,
+        private readonly SessionCorrelationIdService $correlationIdService,
         private readonly LoggerInterface $logger
     ) {
     }
@@ -81,6 +83,7 @@ class RegistrationController extends AbstractController
             'default/registration.html.twig',
             [
                 'metadataUrl' => sprintf("tiqrenroll://%s", $metadataUrl),
+                'correlationLoggingId' => $this->correlationIdService->generateCorrelationId(),
                 'enrollmentKey' => $key
             ]
         );

--- a/src/EventSubscriber/RequiresActiveSessionAttributeListener.php
+++ b/src/EventSubscriber/RequiresActiveSessionAttributeListener.php
@@ -41,8 +41,9 @@ final readonly class RequiresActiveSessionAttributeListener implements EventSubs
     private string $sessionName;
 
     public function __construct(
-        private LoggerInterface             $logger,
+        private LoggerInterface $logger,
         private SessionCorrelationIdService $sessionCorrelationIdService,
+        /** @var array<string, string> */
         private array $sessionOptions,
     ) {
         if (!array_key_exists('name', $this->sessionOptions)) {

--- a/src/EventSubscriber/SessionStateListener.php
+++ b/src/EventSubscriber/SessionStateListener.php
@@ -39,6 +39,7 @@ final readonly class SessionStateListener implements EventSubscriberInterface
     public function __construct(
         private LoggerInterface $logger,
         private SessionCorrelationIdService $sessionCorrelationIdService,
+        /** @var array<string, string> */
         private array $sessionOptions,
     ) {
         if (!array_key_exists('name', $this->sessionOptions)) {

--- a/src/Service/SessionCorrelationIdService.php
+++ b/src/Service/SessionCorrelationIdService.php
@@ -29,6 +29,7 @@ final readonly class SessionCorrelationIdService
 
     public function __construct(
         private RequestStack $requestStack,
+        /** @var array<string, string> */
         private array $sessionOptions,
         private string $sessionCorrelationSalt,
     ) {

--- a/src/Tiqr/Legacy/TiqrService.php
+++ b/src/Tiqr/Legacy/TiqrService.php
@@ -38,7 +38,6 @@ use Tiqr_HealthCheck_Interface;
 use Tiqr_Service;
 use Tiqr_StateStorage_StateStorageInterface;
 
-
 /**
  * Wrapper around the legacy Tiqr service.
  *

--- a/templates/default/authentication.html.twig
+++ b/templates/default/authentication.html.twig
@@ -16,7 +16,8 @@
          */
         var authenticationPageService = window.bootstrapAuthentication(
             "{{ path('app_identity_authentication_status') | escape('js') }}",
-            "{{ path('app_identity_authentication_notification') | escape('js') }}"
+            "{{ path('app_identity_authentication_notification') | escape('js') }}",
+            "{{ correlationLoggingId }}"
         );
     </script>
 {% endblock %}

--- a/templates/default/registration.html.twig
+++ b/templates/default/registration.html.twig
@@ -13,7 +13,8 @@
     <script>
         var registrationStateMachine = window.bootstrapRegistration(
             "{{ path('app_identity_registration_status') | escape('js') }}",
-            "{{ path('app_identity_registration') | escape('js') }}"
+            "{{ path('app_identity_registration') | escape('js') }}",
+            "{{ correlationLoggingId }}"
         );
     </script>
 {% endblock %}

--- a/tests/Unit/EventSubscriber/RequiresActiveSessionAttributeListenerTest.php
+++ b/tests/Unit/EventSubscriber/RequiresActiveSessionAttributeListenerTest.php
@@ -66,7 +66,14 @@ final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
         $mockLogger = Mockery::mock(LoggerInterface::class);
         $mockLogger->shouldNotReceive('log');
 
-        $listener = new RequiresActiveSessionAttributeListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService(
+                $requestStack,
+                ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'
+            ),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -103,7 +110,11 @@ final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
                 ['correlationId' => '', 'route' => '/route']
             );
 
-        $listener = new RequiresActiveSessionAttributeListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -144,7 +155,11 @@ final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
                 ['correlationId' => '', 'route' => '/route']
             );
 
-        $listener = new RequiresActiveSessionAttributeListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -185,7 +200,11 @@ final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
                 ['correlationId' => 'f6e7cfb6f0861f577c48f171e27542236b1184f7a599dde82aca1640d86da961', 'route' => '/route']
             );
 
-        $listener = new RequiresActiveSessionAttributeListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -219,7 +238,11 @@ final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
         $mockLogger = Mockery::mock(LoggerInterface::class);
         $mockLogger->shouldNotReceive('log');
 
-        $listener = new RequiresActiveSessionAttributeListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);

--- a/tests/Unit/EventSubscriber/SessionStateListenerTest.php
+++ b/tests/Unit/EventSubscriber/SessionStateListenerTest.php
@@ -56,7 +56,11 @@ final class SessionStateListenerTest extends KernelTestCase
             ->once()
             ->with(LogLevel::INFO, 'User made a request without a session cookie.', ['correlationId' => '', 'route' => '/route']);
 
-        $listener = new SessionStateListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSIONID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -85,7 +89,11 @@ final class SessionStateListenerTest extends KernelTestCase
             ->once()
             ->with(LogLevel::INFO, 'Session not found.', ['correlationId' => 'f6e7cfb6f0861f577c48f171e27542236b1184f7a599dde82aca1640d86da961', 'route' => '/route']);
 
-        $listener = new SessionStateListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -121,7 +129,11 @@ final class SessionStateListenerTest extends KernelTestCase
             ->once()
             ->with(LogLevel::ERROR, 'The session cookie does not match the session id.', ['correlationId' => 'f6e7cfb6f0861f577c48f171e27542236b1184f7a599dde82aca1640d86da961', 'route' => '/route']);
 
-        $listener = new SessionStateListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);
@@ -158,7 +170,11 @@ final class SessionStateListenerTest extends KernelTestCase
             ->once()
             ->with(LogLevel::INFO, 'User session matches the session cookie.', ['correlationId' => 'f6e7cfb6f0861f577c48f171e27542236b1184f7a599dde82aca1640d86da961', 'route' => '/route']);
 
-        $listener = new SessionStateListener($mockLogger, new SessionCorrelationIdService($requestStack));
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
 
         $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
         $dispatcher->dispatch($event, KernelEvents::REQUEST);

--- a/tests/Unit/Service/SessionCorrelationIdServiceTest.php
+++ b/tests/Unit/Service/SessionCorrelationIdServiceTest.php
@@ -30,7 +30,7 @@ final class SessionCorrelationIdServiceTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $service = new SessionCorrelationIdService($requestStack);
+        $service = new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ');
 
         $this->assertNull($service->generateCorrelationId());
     }
@@ -41,7 +41,7 @@ final class SessionCorrelationIdServiceTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $service = new SessionCorrelationIdService($requestStack);
+        $service = new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ');
 
         $this->assertSame('f6e7cfb6f0861f577c48f171e27542236b1184f7a599dde82aca1640d86da961', $service->generateCorrelationId());
     }

--- a/tests/Unit/Session/LoggingSessionFactoryTest.php
+++ b/tests/Unit/Session/LoggingSessionFactoryTest.php
@@ -45,7 +45,7 @@ final class LoggingSessionFactoryTest extends TestCase
             $requestStack,
             $this->createStub(SessionStorageFactoryInterface::class),
             $mockLogger,
-            new SessionCorrelationIdService($requestStack),
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
         );
 
         $this->assertInstanceOf(SessionInterface::class, $sessionFactory->createSession());


### PR DESCRIPTION
The polling async requests should include the correlation id based on the session id of the user that is placing them.

That way we can correlate between the access  logs and the application logs.