### PR TITLE
Tweak dependabot & fix dev bug

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    ignore:
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]

--- a/dev/Command/AuthenticationCommand.php
+++ b/dev/Command/AuthenticationCommand.php
@@ -176,12 +176,16 @@ class AuthenticationCommand extends Command
         $qrcode = new QrReader(file_get_contents($file), QrReader::SOURCE_TYPE_BLOB);
         $link = $qrcode->text();
 
+        if (!is_string($link)) {
+            throw new RuntimeException('QR code could not be read');
+        }
+
         $output->writeln([
             'Registration link result: ',
             $this->decorateResult($link),
         ]);
 
-        return $link->toString();
+        return $link;
     }
 
     /**


### PR DESCRIPTION
Prior to this change, dependabot would create pr's to upgrade from Symfony 6.4 to Symfony 7.1. We don't want this, because 7.1 will be eol in a couple of months, which can the increase maintenance burden. We will upgrade to 7.4 lts once it is released.