### PR TITLE
4. Improve logging on session related errors

### DIFF
--- a/config/openconext/parameters.yaml.dist
+++ b/config/openconext/parameters.yaml.dist
@@ -7,6 +7,9 @@ parameters:
     # A secret key that's used to generate certain security-related tokens
     app_secret: ThisTokenIsNotSoSecretChangeIt
 
+    # A secret salt used to hash the correlationId for logging based on the session_id
+    correlation_id_salt: 'changeMeToAtLeast16CharsOfRandomString'
+
     # All locales supported by the application
     default_locale: en_GB
     locales:

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -14,8 +14,10 @@ framework:
     # Remove or comment this section to explicitly disable session support.
     session:
         handler_id: null
-        cookie_secure: auto
+        cookie_secure: true
         cookie_samesite: none
+        name: sess_tiqr
+        cookie_httponly: true
     router:
         strict_requirements: null
         utf8: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,6 +19,8 @@ services:
             $locales: '%locales%'
             $tiqrConfiguration: '%tiqr_library_options%'
             $appSecret: '%app_secret%'
+            $sessionOptions: '%session.storage.options%'
+            $correlationIdSalt: '%correlation_id_salt%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Attribute/RequiresActiveSession.php
+++ b/src/Attribute/RequiresActiveSession.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Surfnet\Tiqr\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class RequiresActiveSession
+{
+}

--- a/src/Controller/AuthenticationNotificationController.php
+++ b/src/Controller/AuthenticationNotificationController.php
@@ -25,6 +25,7 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Surfnet\GsspBundle\Service\AuthenticationService;
 use Surfnet\GsspBundle\Service\StateHandlerInterface;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
 use Surfnet\Tiqr\Tiqr\Exception\UserNotExistsException;
 use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
 use Surfnet\Tiqr\Tiqr\TiqrUserRepositoryInterface;
@@ -52,6 +53,7 @@ class AuthenticationNotificationController extends AbstractController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/authentication/notification', name: 'app_identity_authentication_notification', methods: ['POST'])]
+    #[RequiresActiveSession]
     public function __invoke(): Response
     {
         $nameId = $this->authenticationService->getNameId();

--- a/src/Controller/AuthenticationQrController.php
+++ b/src/Controller/AuthenticationQrController.php
@@ -24,6 +24,7 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Surfnet\GsspBundle\Service\AuthenticationService;
 use Surfnet\GsspBundle\Service\StateHandlerInterface;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
 use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
 use Surfnet\Tiqr\WithContextLogger;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,6 +45,7 @@ class AuthenticationQrController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/authentication/qr', name: 'app_identity_authentication_qr', methods: ['GET'])]
+    #[RequiresActiveSession]
     public function __invoke(): Response
     {
         $nameId = $this->authenticationService->getNameId();

--- a/src/Controller/AuthenticationStatusController.php
+++ b/src/Controller/AuthenticationStatusController.php
@@ -25,6 +25,7 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Surfnet\GsspBundle\Service\AuthenticationService;
 use Surfnet\GsspBundle\Service\StateHandlerInterface;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
 use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
 use Surfnet\Tiqr\WithContextLogger;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -44,6 +45,7 @@ class AuthenticationStatusController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/authentication/status', name: 'app_identity_authentication_status', methods: ['GET'])]
+    #[RequiresActiveSession]
     public function __invoke(): JsonResponse
     {
         try {
@@ -56,7 +58,6 @@ class AuthenticationStatusController
                 $logger->error('There is no pending authentication request from SP');
                 return $this->refreshAuthenticationPage();
             }
-
 
             $isAuthenticated = $this->tiqrService->isAuthenticated();
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -23,6 +23,7 @@ namespace Surfnet\Tiqr\Controller;
 use Psr\Log\LoggerInterface;
 use Surfnet\GsspBundle\Service\RegistrationService;
 use Surfnet\GsspBundle\Service\StateHandlerInterface;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
 use Surfnet\Tiqr\Exception\NoActiveAuthenrequestException;
 use Surfnet\Tiqr\Tiqr\Legacy\TiqrService;
 use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
@@ -90,9 +91,8 @@ class RegistrationController extends AbstractController
      *
      *
      * @throws \InvalidArgumentException
-     *
-     * Requires session cookie to be set to a valid session.
      */
+    #[RequiresActiveSession]
     #[Route(path: '/registration/status', name: 'app_identity_registration_status', methods: ['GET'])]
     public function registrationStatus() : Response
     {
@@ -123,6 +123,7 @@ class RegistrationController extends AbstractController
      *
      * @throws \InvalidArgumentException
      */
+    #[RequiresActiveSession]
     #[Route(path: '/registration/qr/{enrollmentKey}', name: 'app_identity_registration_qr', methods: ['GET'])]
     public function registrationQr(Request $request, string $enrollmentKey): Response
     {

--- a/src/EventSubscriber/RequiresActiveSessionAttributeListener.php
+++ b/src/EventSubscriber/RequiresActiveSessionAttributeListener.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Surfnet\Tiqr\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Surfnet\Tiqr\WithContextLogger;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use function is_array;
+
+/**
+ * This listener acts when the given route has a #[RequiresActiveSession] attribute.
+ * When a route is marked as to have a required active session this listener will deny access when there is none.
+ */
+final readonly class RequiresActiveSessionAttributeListener implements EventSubscriberInterface
+{
+    private string $sessionName;
+
+    /**
+     * @param array<string, string> $sessionOptions
+     */
+    public function __construct(
+        private LoggerInterface $logger,
+        private SessionCorrelationIdService $sessionCorrelationIdService,
+        private array $sessionOptions,
+    ) {
+        if (!array_key_exists('name', $this->sessionOptions)) {
+            throw new RuntimeException(
+                'The session name (PHP session cookie identifier) could not be found in the session configuration.'
+            );
+        }
+        $this->sessionName = $this->sessionOptions['name'];
+    }
+
+    public function onKernelControllerArguments(ControllerArgumentsEvent $event): void
+    {
+        if (!is_array($event->getAttributes()[RequiresActiveSession::class] ?? null)) {
+            return;
+        }
+
+        $logger = WithContextLogger::from($this->logger, [
+            'correlationId' => $this->sessionCorrelationIdService->generateCorrelationId() ?? '',
+            'route' => $event->getRequest()->getRequestUri(),
+        ]);
+
+        try {
+            $sessionId = $event->getRequest()->getSession()->getId();
+            $sessionCookieId = $event->getRequest()->cookies->get($this->sessionName);
+
+            if (!$sessionCookieId) {
+                $logger->error('Route requires active session. Active session wasn\'t found. No session cookie was set.');
+
+                throw new AccessDeniedException();
+            }
+
+            if ($sessionId !== $sessionCookieId) {
+                $logger->error('Route requires active session. Session does not match session cookie.');
+
+                throw new AccessDeniedException();
+            }
+        } catch (SessionNotFoundException) {
+            $logger->error('Route requires active session. Active session wasn\'t found.');
+
+            throw new AccessDeniedException();
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER_ARGUMENTS => ['onKernelControllerArguments', 20]];
+    }
+}

--- a/src/EventSubscriber/SessionStateListener.php
+++ b/src/EventSubscriber/SessionStateListener.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Surfnet\Tiqr\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Surfnet\Tiqr\WithContextLogger;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Listen to all incoming requests and log the session state information.
+ */
+final readonly class SessionStateListener implements EventSubscriberInterface
+{
+    private string $sessionName;
+
+    /**
+     * @param array<string, string> $sessionOptions
+     */
+    public function __construct(
+        private LoggerInterface $logger,
+        private SessionCorrelationIdService $sessionCorrelationIdService,
+        private array $sessionOptions,
+    ) {
+        if (!array_key_exists('name', $this->sessionOptions)) {
+            throw new RuntimeException(
+                'The session name (PHP session cookie identifier) could not be found in the session configuration.'
+            );
+        }
+        $this->sessionName = $this->sessionOptions['name'];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $logger = WithContextLogger::from($this->logger, [
+            'correlationId' => $this->sessionCorrelationIdService->generateCorrelationId() ?? '',
+            'route' => $event->getRequest()->getRequestUri(),
+        ]);
+
+        $sessionCookieId = $event->getRequest()->cookies->get($this->sessionName);
+        if ($sessionCookieId === null) {
+            $logger->info('User made a request without a session cookie.');
+            return;
+        }
+
+        $logger->info('User made a request with a session cookie.');
+
+        try {
+            $sessionId = $event->getRequest()->getSession()->getId();
+            $logger->info('User has a session.');
+
+            if ($sessionId !== $sessionCookieId) {
+                $logger->error('The session cookie does not match the session id.');
+                return;
+            }
+        } catch (SessionNotFoundException) {
+            $logger->info('Session not found.');
+            return;
+        }
+
+        $logger->info('User session matches the session cookie.');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::REQUEST => ['onKernelRequest', 20]];
+    }
+}

--- a/src/Service/SessionCorrelationIdService.php
+++ b/src/Service/SessionCorrelationIdService.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Surfnet\Tiqr\Service;
+
+use RuntimeException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final readonly class SessionCorrelationIdService
+{
+    private string $sessionName;
+    private ?string $correlationIdSalt;
+
+    /**
+     * @param array<string, string> $sessionOptions
+     */
+    public function __construct(
+        private RequestStack $requestStack,
+        array $sessionOptions,
+        ?string $correlationIdSalt = null,
+    ) {
+        if (!array_key_exists('name', $sessionOptions)) {
+            throw new RuntimeException(
+                'The session name (PHP session cookie identifier) could not be found in the session configuration.'
+            );
+        }
+        $this->correlationIdSalt = is_null($correlationIdSalt) || strlen($correlationIdSalt) < 16 ? null : $correlationIdSalt;
+        $this->sessionName = $sessionOptions['name'];
+    }
+
+    public function generateCorrelationId(): ?string
+    {
+        if ($this->correlationIdSalt === null) {
+            return null;
+        }
+
+        $sessionCookie = $this->requestStack->getMainRequest()?->cookies->get($this->sessionName);
+
+        if ($sessionCookie === null) {
+            return null;
+        }
+
+        return substr(hash('sha256', $sessionCookie.$this->correlationIdSalt), 0, 8);
+    }
+}

--- a/src/Session/LoggingSessionFactory.php
+++ b/src/Session/LoggingSessionFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\Tiqr\Session;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Surfnet\Tiqr\WithContextLogger;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionFactory;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+
+/**
+ * This class serves as a decorated version of Symfony's SessionFactory class.
+ * Every time a session is created, we'll add a log entry that can be identified by the correlation id.
+ *
+ * For this logging function to work we need a stateless logger, therefore we inject the default logger by using the variable name $monoLogger.
+ * The variable name $logger has been bound to the Surfnet GSSP logger in the Symfony container, so we'll need to use another variable name.
+ * The Surfnet GSSP Logger isn't stateless as it's dependent on the current session, which has not been created when the logging occurs.
+ *
+ * @see SessionFactory::createSession()
+ */
+#[AsDecorator('session.factory')]
+final class LoggingSessionFactory extends SessionFactory
+{
+    private LoggerInterface $logger;
+
+    public function __construct(
+        RequestStack                   $requestStack,
+        #[Autowire(service: 'session.storage.factory')]
+        SessionStorageFactoryInterface $storageFactory,
+        LoggerInterface                $monologLogger,
+        SessionCorrelationIdService    $sessionCorrelationIdService,
+        ?callable                      $usageReporter = null,
+    ) {
+        $this->logger = WithContextLogger::from(
+            $monologLogger,
+            ['correlationId' => $sessionCorrelationIdService->generateCorrelationId() ?? ''],
+        );
+
+        parent::__construct($requestStack, $storageFactory, $usageReporter);
+    }
+
+    public function createSession(): SessionInterface
+    {
+        $this->logger->info('Created new session.');
+
+        return parent::createSession();
+    }
+}

--- a/src/Tiqr/Legacy/TiqrService.php
+++ b/src/Tiqr/Legacy/TiqrService.php
@@ -38,7 +38,6 @@ use Tiqr_HealthCheck_Interface;
 use Tiqr_Service;
 use Tiqr_StateStorage_StateStorageInterface;
 
-
 /**
  * Wrapper around the legacy Tiqr service.
  *

--- a/tests/Unit/EventSubscriber/RequiresActiveSessionAttributeListenerTest.php
+++ b/tests/Unit/EventSubscriber/RequiresActiveSessionAttributeListenerTest.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit\EventSubscriber;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Surfnet\Tiqr\Attribute\RequiresActiveSession;
+use Surfnet\Tiqr\EventSubscriber\RequiresActiveSessionAttributeListener;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class RequiresActiveSessionAttributeListenerTest extends KernelTestCase
+{
+    private const SESSION_ID = 'session-id';
+
+    public function testControllersWithoutTheRequiresActiveSessionAttributeAreIgnored(): void
+    {
+        self::bootKernel();
+
+        $request = new Request(server: ['REQUEST_URI' => '/route']);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $stubControllerFactory = fn() => new class extends AbstractController {
+        };
+
+        $event = new ControllerArgumentsEvent(
+            self::$kernel,
+            $stubControllerFactory,
+            [], $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->never())->method('log');
+
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService(
+                $requestStack,
+                ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'
+            ),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItDeniesAccessWhenThereIsNoActiveSession(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Access Denied.');
+
+        self::bootKernel();
+
+        $request = new Request(server: ['REQUEST_URI' => '/route']);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $stubControllerFactory = fn() => new class extends AbstractController {
+        };
+
+        $requestType = HttpKernelInterface::MAIN_REQUEST;
+        $controllerEvent = new ControllerEvent(self::$kernel, $stubControllerFactory, $request, $requestType);
+        $controllerEvent->setController($stubControllerFactory, [RequiresActiveSession::class => [null]]);
+        $event = new ControllerArgumentsEvent(self::$kernel, $controllerEvent, [], $request, $requestType);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::ERROR,
+                'Route requires active session. Active session wasn\'t found.',
+                ['correlationId' => '', 'route' => '/route']
+            );
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItDeniesAccessWhenThereIsNoSessionCookie(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Access Denied.');
+
+        self::bootKernel();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->setId(self::SESSION_ID);
+
+        $request = new Request(server: ['REQUEST_URI' => '/route']);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $stubControllerFactory = fn() => new class extends AbstractController {
+        };
+
+        $requestType = HttpKernelInterface::MAIN_REQUEST;
+        $controllerEvent = new ControllerEvent(self::$kernel, $stubControllerFactory, $request, $requestType);
+        $controllerEvent->setController($stubControllerFactory, [RequiresActiveSession::class => [null]]);
+        $event = new ControllerArgumentsEvent(self::$kernel, $controllerEvent, [], $request, $requestType);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::ERROR,
+                'Route requires active session. Active session wasn\'t found. No session cookie was set.',
+                ['correlationId' => '', 'route' => '/route']
+            );
+
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItDeniesAccessWhenTheActiveSessionDoesNotMatchTheSessionCookie(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Access Denied.');
+
+        self::bootKernel();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->setId('erroneous-session-id');
+
+        $request = new Request(server: ['REQUEST_URI' => '/route'], cookies: ['PHPSESSID' => self::SESSION_ID]);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $stubControllerFactory = fn() => new class extends AbstractController {
+        };
+
+        $requestType = HttpKernelInterface::MAIN_REQUEST;
+        $controllerEvent = new ControllerEvent(self::$kernel, $stubControllerFactory, $request, $requestType);
+        $controllerEvent->setController($stubControllerFactory, [RequiresActiveSession::class => [null]]);
+        $event = new ControllerArgumentsEvent(self::$kernel, $controllerEvent, [], $request, $requestType);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::ERROR,
+                'Route requires active session. Session does not match session cookie.',
+                ['correlationId' => 'f02614d0', 'route' => '/route']
+            );
+
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItDoesNotThrowWhenTheActiveSessionMatchesTheSessionCookie(): void
+    {
+        self::bootKernel();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->setId(self::SESSION_ID);
+
+        $request = new Request(server: ['REQUEST_URI' => '/route'], cookies: ['PHPSESSID' => self::SESSION_ID]);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $stubControllerFactory = fn() => new class extends AbstractController {
+        };
+
+        $requestType = HttpKernelInterface::MAIN_REQUEST;
+        $controllerEvent = new ControllerEvent(self::$kernel, $stubControllerFactory, $request, $requestType);
+        $controllerEvent->setController($stubControllerFactory, [RequiresActiveSession::class => [null]]);
+        $event = new ControllerArgumentsEvent(self::$kernel, $controllerEvent, [], $request, $requestType);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->never())->method('log');
+
+        $listener = new RequiresActiveSessionAttributeListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelControllerArguments']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+}

--- a/tests/Unit/EventSubscriber/SessionStateListenerTest.php
+++ b/tests/Unit/EventSubscriber/SessionStateListenerTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit\EventSubscriber;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Surfnet\Tiqr\EventSubscriber\SessionStateListener;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class SessionStateListenerTest extends KernelTestCase
+{
+    private const SESSION_ID = 'session-id';
+
+    public function testItLogsWhenUserHasNoSessionCookie(): void
+    {
+        self::bootKernel();
+
+        $request = new Request(server: ['REQUEST_URI' => '/route']);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::INFO,
+                'User made a request without a session cookie.',
+                ['correlationId' => '', 'route' => '/route']
+            );
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSIONID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItLogsWhenUserHasNoSession(): void
+    {
+        self::bootKernel();
+
+        $request = new Request(server: ['REQUEST_URI' => '/route'], cookies: ['PHPSESSID' => self::SESSION_ID]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+
+        $mockLogger->expects($this->exactly(2))
+            ->method('log')
+            ->willReturnCallback(function ($level, $message, $context) {
+                static $calledMessages = [];
+
+                if (isset($calledMessages[$message])) {
+                    $this->fail('Log message "' . $message . '" was called more than once.');
+                }
+                $calledMessages[$message] = true;
+
+                switch($message) {
+                    case 'Session not found.':
+                    case 'User made a request with a session cookie.':
+                        $this->assertSame(LogLevel::INFO, $level);
+                        $this->assertSame('f02614d0', $context['correlationId']);
+                        $this->assertSame('/route', $context['route']);
+                        break;
+                    default:
+                        $this->fail('Unexpected log message');
+                }
+
+            })
+        ;
+
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testItLogsAnErrorWhenTheSessionIdDoesNotMatchTheSessionCookie(): void
+    {
+        self::bootKernel();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->setId('erroneous-session-id');
+
+        $request = new Request(server: ['REQUEST_URI' => '/route'], cookies: ['PHPSESSID' => self::SESSION_ID]);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->exactly(3))
+            ->method('log')
+            ->willReturnCallback(function ($level, $message, $context) {
+                static $calledMessages = [];
+
+                if (isset($calledMessages[$message])) {
+                    $this->fail('Log message "' . $message . '" was called more than once.');
+                }
+                $calledMessages[$message] = true;
+
+                switch($message) {
+                    case 'User made a request with a session cookie.':
+                    case 'User has a session.':
+                    case 'The session cookie does not match the session id.':
+                        $this->assertSame($level === LogLevel::ERROR ? LogLevel::ERROR : LogLevel::INFO, $level);
+                        $this->assertSame('f02614d0', $context['correlationId']);
+                        $this->assertSame('/route', $context['route']);
+                        break;
+                    default:
+                        $this->fail('Unexpected log message');
+                }
+            });
+
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+
+    public function testTheUserSessionMatchesTheSessionCookie(): void
+    {
+        self::bootKernel();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->setId(self::SESSION_ID);
+
+        $request = new Request(server: ['REQUEST_URI' => '/route'], cookies: ['PHPSESSID' => self::SESSION_ID]);
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $dispatcher = new EventDispatcher();
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->exactly(3))
+            ->method('log')
+            ->willReturnCallback(function ($level, $message, $context) {
+                static $calledMessages = [];
+
+                if (isset($calledMessages[$message])) {
+                    $this->fail('Log message "' . $message . '" was called more than once.');
+                }
+                $calledMessages[$message] = true;
+
+                switch($message) {
+                    case 'User made a request with a session cookie.':
+                    case 'User has a session.':
+                    case 'User session matches the session cookie.':
+                        $this->assertSame(LogLevel::INFO, $level);
+                        $this->assertSame('f02614d0', $context['correlationId']);
+                        $this->assertSame('/route', $context['route']);
+                        break;
+                    default:
+                        $this->fail('Unexpected log message');
+                }
+            });
+
+        $listener = new SessionStateListener(
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+            ['name' => 'PHPSESSID'],
+        );
+
+        $dispatcher->addListener(KernelEvents::REQUEST, [$listener, 'onKernelRequest']);
+        $dispatcher->dispatch($event, KernelEvents::REQUEST);
+    }
+}

--- a/tests/Unit/Service/SessionCorrelationIdServiceTest.php
+++ b/tests/Unit/Service/SessionCorrelationIdServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit\Service;
+
+use PHPUnit\Framework\TestCase;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class SessionCorrelationIdServiceTest extends TestCase
+{
+    public function testItHasNoCorrelationIdWhenThereIsNoSessionCookie(): void
+    {
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $service = new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ');
+
+        $this->assertNull($service->generateCorrelationId());
+    }
+
+    public function testItGeneratesACorrelationIdBasedOnTheSessionCookie(): void
+    {
+        $request = new Request(cookies: ['PHPSESSID' => 'session-id']);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $service = new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'
+        );
+
+        $this->assertSame('f02614d0', $service->generateCorrelationId());
+    }
+
+
+    /**
+     * @dataProvider saltProvider
+     */
+    public function testItWillNotGenerateACorrelationIdWithoutAdequateSalt(?string $salt): void
+    {
+        $request = new Request(cookies: ['PHPSESSID' => 'session-id']);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $service = new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], $salt);
+
+        $this->assertNull($service->generateCorrelationId());
+    }
+
+    public function saltProvider(): array
+    {
+        return [
+            'empty salt' => [''],
+            'null salt' => [null],
+            'short salt' => ['abc'],
+            'almost_long_enough salt' => ['1234567890ABCDE'],
+        ];
+    }
+}

--- a/tests/Unit/Session/LoggingSessionFactoryTest.php
+++ b/tests/Unit/Session/LoggingSessionFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit\Session;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Surfnet\Tiqr\Service\SessionCorrelationIdService;
+use Surfnet\Tiqr\Session\LoggingSessionFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+
+final class LoggingSessionFactoryTest extends TestCase
+{
+    public function testItLogsWheneverASessionIsCreated(): void
+    {
+        $request = new Request(cookies: ['PHPSESSID' => 'session-id']);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::INFO,
+                'Created new session.',
+                ['correlationId' => 'f02614d0']
+            );
+
+        $sessionFactory = new LoggingSessionFactory(
+            $requestStack,
+            $this->createStub(SessionStorageFactoryInterface::class),
+            $mockLogger,
+            new SessionCorrelationIdService($requestStack, ['name' => 'PHPSESSID'], 'Mr6LpJYtuWRDdVR2_7VgTChFhzQ'),
+        );
+
+        $this->assertInstanceOf(SessionInterface::class, $sessionFactory->createSession());
+    }
+}


### PR DESCRIPTION
Prior to this change there we weren't able to keep track of sessions that got lost.
This change allows us to see every time a session is created and distinguish them by their correlation id.
Log an error on a route that requires an active session when there is none

Prior to this change all routes were able to called, even though the user might not have had an active session
This change will start logging errors when the session wasn't found, or is in an unexpected state

Prior to this change session information got lost. We had no way of tracking down what happened to user sessions in the logs.
This change logs whether a session existed and if it's in a valid state. Log information is enriched with a correlation id to be able to distinguish them.

See https://www.pivotaltracker.com/n/projects/1163646/stories/188205214