### PR TITLE
Fix: Actually apply the trusted device cookie to the browser

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -21,3 +21,9 @@ services:
         public: true
         arguments:
             $filePath: '/var/www/html/var/gssp_store.json'
+
+    Surfnet\Tiqr\Features\Context\TiqrContext:
+        autowire: true
+        autoconfigure: true
+        arguments:
+            $store: '@surfnet_gssp.value_store.service'

--- a/src/Features/Context/WebContext.php
+++ b/src/Features/Context/WebContext.php
@@ -22,6 +22,7 @@ namespace Surfnet\Tiqr\Features\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\MinkExtension\Context\MinkContext;
 use Exception;
 use RobRichards\XMLSecLibs\XMLSecurityKey;

--- a/src/Features/authentication.feature
+++ b/src/Features/authentication.feature
@@ -4,7 +4,7 @@ Feature: When an user needs to authenticate
 
   Background:
     Given the registration QR code is scanned
-    When the user registers the service
+    When the user registers the service with notification type "APNS" address: "0000000000111111111122222222223333333333"
     Then we have a registered user
     And I clear the logs
 
@@ -32,6 +32,7 @@ Feature: When an user needs to authenticate
 
     # Service provider AuthNRequest response page
     Then I should see "urn:oasis:names:tc:SAML:2.0:status:Success"
+    And I should see the trusted device cookie for address "0000000000111111111122222222223333333333"
 
     And the logs are:
       | level  | message                                                                                                                                   | sari    |
@@ -91,6 +92,7 @@ Feature: When an user needs to authenticate
       | info   | Authentication is finalized, returning to SP                                                                                              | present |
       | notice | Application authenticates the user                                                                                                        | present |
       | notice | Created redirect response for sso return endpoint "/saml/sso_return"                                                                      | present |
+      | notice | /Writing a trusted-device cookie with fingerprint .*/                                                                                     | present |
       | info   | User made a request with a session cookie.                                                                                                | present |
       | info   | Created new session.                                                                                                                      |         |
       | info   | User has a session.                                                                                                                       | present |
@@ -105,7 +107,7 @@ Feature: When an user needs to authenticate
       | info   | User session matches the session cookie.                                                                                                  |         |
       | info   | /SAMLResponse with id ".*" was not signed at root level, not attempting to verify the signature of the reponse itself/                    |         |
       | info   | /Verifying signature of Assertion with id ".*"/                                                                                           |         |
-
+      | notice | /Reading a trusted-device cookie with fingerprint .*/                                                                                     |         |
 
   Scenario: When an user cancels it's authentication
     # Service provider demo page
@@ -200,6 +202,7 @@ Feature: When an user needs to authenticate
 
     # Service provider AuthNRequest response page
     Then I should see "urn:oasis:names:tc:SAML:2.0:status:Success"
+    And I should see the trusted device cookie
 
     And the logs are:
       | level  | message                                                                                                                                   | sari    |
@@ -256,6 +259,7 @@ Feature: When an user needs to authenticate
       | info   | Authentication is finalized, returning to SP                                                                                              | present |
       | notice | Application authenticates the user                                                                                                        | present |
       | notice | Created redirect response for sso return endpoint "/saml/sso_return"                                                                      | present |
+      | notice | /Writing a trusted-device cookie with fingerprint .*/                                                                                     | present |
       | info   | User made a request with a session cookie.                                                                                                | present |
       | info   | Created new session.                                                                                                                      |         |
       | info   | User has a session.                                                                                                                       | present |
@@ -270,4 +274,5 @@ Feature: When an user needs to authenticate
       | info   | User session matches the session cookie.                                                                                                  |         |
       | info   | /SAMLResponse with id ".*" was not signed at root level, not attempting to verify the signature of the reponse itself/                    |         |
       | info   | /Verifying signature of Assertion with id ".*"/                                                                                           |         |
+
 

--- a/src/Features/mfaFatigueMitigation.feature
+++ b/src/Features/mfaFatigueMitigation.feature
@@ -6,21 +6,8 @@ Feature: When an user needs to authenticate
     Given the registration QR code is scanned
     And the user registers the service with notification type "APNS" address: "0000000000111111111122222222223333333333"
     Then we have a registered user
-    And the logs should mention: Writing a trusted-device cookie with fingerprint
     And I clear the logs
     And the trusted device cookie is cleared
-
-  Scenario: When a user authenticates using a qr code it should set a trusted cookie
-    Given I am on "/demo/sp"
-    And I fill in "NameID" with my identifier
-    When I press "authenticate"
-    Then I should see "Log in with tiqr"
-    And I should be on "/authentication"
-
-    Then I scan the tiqr authentication qrcode
-    And the app authenticates to the service with notification type "APNS" address: "0000000000111111111122222222223333333333"
-    Then we have a authenticated app
-    And we have a trusted cookie for address: "0000000000111111111122222222223333333333"
 
   Scenario: When a user authenticates without a trusted cookie, a push notification should not be sent
     Given I am on "/demo/sp"

--- a/src/Features/registration.feature
+++ b/src/Features/registration.feature
@@ -21,85 +21,91 @@ Feature: When an user needs to register for a new token
     Then I press "Submit"
 
     Then I should see "urn:oasis:names:tc:SAML:2.0:status:Success"
+    And I should see the trusted device cookie for address "0000000000111111111122222222223333333333"
 
     And the logs are:
-      | level   | message                                                                                                                                   | sari    |
+      | level  | message                                                                                                                                   | sari    |
 
-      | info    | User made a request without a session cookie.                                                                                             | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User made a request without a session cookie.                                                                                             | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User made a request without a session cookie.                                                                                             | present |
-      | notice  | Received sso request                                                                                                                      |         |
-      | warning | There is already state present, clear previous state                                                                                      |         |
-      | info    | Processing AuthnRequest                                                                                                                   |         |
-      | notice  | /AuthnRequest processing complete, received AuthnRequest from "https:\/\/tiqr\.dev\.openconext\.local\/saml\/metadata", request ID: ".*"/ |         |
-      | info    | AuthnRequest stored in state                                                                                                              |         |
-      | notice  | Redirect user to the application registration route /registration                                                                         |         |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User made a request without a session cookie.                                                                                             | present |
-      | info    | Verifying if there is a pending registration from SP                                                                                      | present |
-      | info    | There is a pending registration                                                                                                           | present |
-      | info    | Verifying if registration is finalized                                                                                                    | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | notice  | Unable to retrieve the state storage value, file not found                                                                                | present |
-      | info    | Registration is not finalized return QR code                                                                                              | present |
-      | info    | Generating enrollment key                                                                                                                 | present |
-      | notice  | /Starting new enrollment session with sessionId .* and userId .*/                                                                         | present |
-      | info    | /Setting SARI '.*' for identifier '.*'/                                                                                                   | present |
-      | info    | User made a request with a session cookie.                                                                                                | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       | present |
-      | info    | User session matches the session cookie.                                                                                                  | present |
-      | info    | Request for registration QR img                                                                                                           | present |
-      | info    | Returning registration QR response                                                                                                        | present |
-      | info    | User made a request with a session cookie.                                                                                                | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       | present |
-      | info    | User session matches the session cookie.                                                                                                  | present |
-      | info    | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
-      | info    | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
-      | notice  | Got GET request to metadata endpoint with enrollment key                                                                                  | present |
-      | info    | /Setting SARI '.*' for identifier '.*'/                                                                                                   | present |
-      | notice  | Returned metadata response                                                                                                                | present |
-      | info    | User made a request with a session cookie.                                                                                                | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       | present |
-      | info    | User session matches the session cookie.                                                                                                  | present |
-      | info    | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
-      | info    | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
-      | notice  | Got POST with registration response                                                                                                       | present |
-      | notice  | Received register action from client with User-Agent "Behat UA" and version ""                                                            | present |
-      | info    | Start validating enrollment secret                                                                                                        | present |
-      | info    | Setting user secret and notification type and address                                                                                     | present |
-      | info    | Finalizing enrollment                                                                                                                     | present |
-      | notice  | Enrollment finalized                                                                                                                      | present |
-      | notice  | /Writing a trusted-device cookie with fingerprint .*/                                                                                     | present |
-      | info    | User made a request with a session cookie.                                                                                                | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       | present |
-      | info    | User session matches the session cookie.                                                                                                  | present |
-      | info    | Verifying if there is a pending registration from SP                                                                                      | present |
-      | info    | There is a pending registration                                                                                                           | present |
-      | info    | Verifying if registration is finalized                                                                                                    | present |
-      | info    | Registration is finalized returning to service provider                                                                                   | present |
-      | notice  | /Application sets the subject nameID to .*/                                                                                               | present |
-      | notice  | Created redirect response for sso return endpoint "/saml/sso_return"                                                                      | present |
-      | info    | User made a request with a session cookie.                                                                                                | present |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       | present |
-      | info    | User session matches the session cookie.                                                                                                  | present |
-      | notice  | Received sso return request                                                                                                               |         |
-      | info    | Create sso response                                                                                                                       |         |
-      | notice  | /Saml response created with id ".*", request ID: ".*"/                                                                                    |         |
-      | notice  | Invalidate current state and redirect user to service provider assertion consumer url "https://tiqr.dev.openconext.local/demo/sp/acs"     |         |
-      | info    | User made a request with a session cookie.                                                                                                |         |
-      | info    | Created new session.                                                                                                                      |         |
-      | info    | User has a session.                                                                                                                       |         |
-      | info    | User session matches the session cookie.                                                                                                  |         |
-      | info    | /SAMLResponse with id ".*?" was not signed at root level, not attempting to verify the signature of the reponse itself/                   |         |
-      | info    | /Verifying signature of Assertion with id ".*"/                                                                                           |         |
-
+      | info   | User made a request without a session cookie.                                                                                             |         |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User made a request without a session cookie.                                                                                             |         |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User made a request without a session cookie.                                                                                             |         |
+      | notice | Received sso request                                                                                                                      |         |
+      | info   | Processing AuthnRequest                                                                                                                   |         |
+      | notice | /AuthnRequest processing complete, received AuthnRequest from "https:\/\/tiqr\.dev\.openconext\.local\/saml\/metadata", request ID: ".*"/ |         |
+      | info   | AuthnRequest stored in state                                                                                                              |         |
+      | notice | Redirect user to the application registration route /registration                                                                         |         |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User made a request without a session cookie.                                                                                             | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Verifying if there is a pending registration from SP                                                                                      | present |
+      | info   | There is a pending registration                                                                                                           | present |
+      | info   | Verifying if registration is finalized                                                                                                    | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | notice | Unable to retrieve the state storage value, file not found                                                                                | present |
+      | info   | Registration is not finalized return QR code                                                                                              | present |
+      | info   | Generating enrollment key                                                                                                                 | present |
+      | notice | /Starting new enrollment session with sessionId .* and userId .*/                                                                         | present |
+      | info   | /Setting SARI '.*' for identifier '.*'/                                                                                                   | present |
+      | info   | User made a request with a session cookie.                                                                                                | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       | present |
+      | info   | User session matches the session cookie.                                                                                                  | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Request for registration QR img                                                                                                           | present |
+      | info   | Returning registration QR response                                                                                                        | present |
+      | info   | User made a request with a session cookie.                                                                                                | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       | present |
+      | info   | User session matches the session cookie.                                                                                                  | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | notice | Got GET request to metadata endpoint with enrollment key                                                                                  | present |
+      | info   | /Setting SARI '.*' for identifier '.*'/                                                                                                   | present |
+      | notice | Returned metadata response                                                                                                                | present |
+      | info   | User made a request with a session cookie.                                                                                                | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       | present |
+      | info   | User session matches the session cookie.                                                                                                  | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | notice | Got POST with registration response                                                                                                       | present |
+      | notice | Received register action from client with User-Agent "Behat UA" and version ""                                                            | present |
+      | info   | Start validating enrollment secret                                                                                                        | present |
+      | info   | Setting user secret and notification type and address                                                                                     | present |
+      | info   | Finalizing enrollment                                                                                                                     | present |
+      | notice | Enrollment finalized                                                                                                                      | present |
+      | info   | User made a request with a session cookie.                                                                                                | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       | present |
+      | info   | User session matches the session cookie.                                                                                                  | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Verifying if there is a pending registration from SP                                                                                      | present |
+      | info   | There is a pending registration                                                                                                           | present |
+      | info   | Verifying if registration is finalized                                                                                                    | present |
+      | info   | Registration is finalized returning to service provider                                                                                   | present |
+      | notice | /Application sets the subject nameID to .*/                                                                                               | present |
+      | notice | Created redirect response for sso return endpoint "/saml/sso_return"                                                                      | present |
+      | notice | /Writing a trusted-device cookie with fingerprint .*/                                                                                       | present |
+      | info   | User made a request with a session cookie.                                                                                                | present |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       | present |
+      | info   | User session matches the session cookie.                                                                                                  | present |
+      | notice | Received sso return request                                                                                                               |         |
+      | info   | Create sso response                                                                                                                       |         |
+      | notice | /Saml response created with id ".*", request ID: ".*"/                                                                                    |         |
+      | notice | Invalidate current state and redirect user to service provider assertion consumer url "https://tiqr.dev.openconext.local/demo/sp/acs"     |         |
+      | info   | User made a request with a session cookie.                                                                                                |         |
+      | info   | Created new session.                                                                                                                      |         |
+      | info   | User has a session.                                                                                                                       |         |
+      | info   | User session matches the session cookie.                                                                                                  |         |
+      | info   | /SAMLResponse with id ".*" was not signed at root level, not attempting to verify the signature of the reponse itself/                    |         |
+      | info   | /Verifying signature of Assertion with id ".*"/                                                                                           |         |
+      | notice | /Reading a trusted-device cookie with fingerprint .*/                                                                                     |         |
 
   Scenario: When an user needs to register for a new token but is unable to scan the QR code
     Given I am on "/demo/sp"
@@ -132,6 +138,8 @@ Feature: When an user needs to register for a new token
       | notice | Redirect user to the application registration route /registration                                                                         |         |
       | info   | Created new session.                                                                                                                      |         |
       | info   | User made a request without a session cookie.                                                                                             | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
       | info   | Verifying if there is a pending registration from SP                                                                                      | present |
       | info   | There is a pending registration                                                                                                           | present |
       | info   | Verifying if registration is finalized                                                                                                    | present |
@@ -162,17 +170,19 @@ Feature: When an user needs to register for a new token
       | info   | Setting user secret and notification type and address                                                                                     | present |
       | info   | Finalizing enrollment                                                                                                                     | present |
       | notice | Enrollment finalized                                                                                                                      | present |
-      | notice | /Writing a trusted-device cookie with fingerprint .*/                                                                                     | present |
       | info   | User made a request with a session cookie.                                                                                                | present |
       | info   | Created new session.                                                                                                                      |         |
       | info   | User has a session.                                                                                                                       | present |
       | info   | User session matches the session cookie.                                                                                                  | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info   | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
       | info   | Verifying if there is a pending registration from SP                                                                                      | present |
       | info   | There is a pending registration                                                                                                           | present |
       | info   | Verifying if registration is finalized                                                                                                    | present |
       | info   | Registration is finalized returning to service provider                                                                                   | present |
       | notice | /Application sets the subject nameID to .*/                                                                                               | present |
       | notice | Created redirect response for sso return endpoint "/saml/sso_return"                                                                      | present |
+      | notice | /Writing a trusted-device cookie with fingerprint .*/                                                                                     | present |
       | info   | User made a request with a session cookie.                                                                                                | present |
       | info   | Created new session.                                                                                                                      |         |
       | info   | User has a session.                                                                                                                       | present |
@@ -220,6 +230,8 @@ Feature: When an user needs to register for a new token
       | notice   | Redirect user to the application registration route /registration                                                                         |         |
       | info     | Created new session.                                                                                                                      |         |
       | info     | User made a request without a session cookie.                                                                                             | present |
+      | info     | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
+      | info     | Using "plain" as UserSecretStorage encryption type                                                                                        | present |
       | info     | Verifying if there is a pending registration from SP                                                                                      | present |
       | info     | There is a pending registration                                                                                                           | present |
       | info     | Verifying if registration is finalized                                                                                                    | present |
@@ -243,7 +255,7 @@ Feature: When an user needs to register for a new token
       | info     | User session matches the session cookie.                                                                                                  | present |
       | notice   | Received sso return request                                                                                                               |         |
       | info     | Create sso response                                                                                                                       |         |
-      | notice   | /Saml response created with id ".*?", request ID: ".*?"/                                                                                  |         |
+      | notice   | /Saml response created with id ".*", request ID: ".*"/                                                                                    |         |
       | notice   | Invalidate current state and redirect user to service provider assertion consumer url "https://tiqr.dev.openconext.local/demo/sp/acs"     |         |
       | info     | User made a request with a session cookie.                                                                                                |         |
       | info     | Created new session.                                                                                                                      |         |

--- a/src/Service/TrustedDeviceHelper.php
+++ b/src/Service/TrustedDeviceHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Surfnet\Tiqr\Service;
+
+use Psr\Log\LoggerInterface;
+use Surfnet\Tiqr\Service\TrustedDevice\TrustedDeviceService;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class TrustedDeviceHelper
+{
+
+    public function __construct(
+        private TrustedDeviceService $cookieService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function handleRegisterTrustedDevice(
+        string $notificationAddress,
+        Response $responseObject
+    ): void {
+        if (trim($notificationAddress) === '') {
+            return;
+        }
+
+        try {
+            $this->cookieService->registerTrustedDevice(
+                $responseObject,
+                $notificationAddress
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning('Could not register trusted device on registration', ['exception' => $e]);
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, the trusted device cookie was applied to the response to the tiqr app. Which was unintended, so the user would always be presented with a qr challenge.
This change puts the cookie on the authentication / registration request to the browser just before it is redirected back.

Fixes https://github.com/OpenConext/Stepup-tiqr/issues/341