### PR TITLE
Feature: Make trusted device cookie toggleable

### DIFF
--- a/config/openconext/parameters.yaml.dist
+++ b/config/openconext/parameters.yaml.dist
@@ -55,6 +55,11 @@ parameters:
     # Should be one of the strings in: \Surfnet\Tiqr\Service\TrustedDevice\Http\CookieSameSite: 'none', 'lax', 'strict'
     trusted_device_cookie_same_site: 'none'
 
+    # Enable/Disable enforcement of MFA fatigue prevention
+    # The trusted device cookie ensures no push notifications are sent when logging in on devices
+    # To prevent everyone having to scan qr codes all of a sudden, enforcement can be temporarily disabled so trusted devices can build up
+    trusted_device_enforcement_enabled: true
+
     # The secret key is used for the authenticated encryption (AE) of the trusted-device cookies, it is stored in the
     # parameters.yaml of Stepup-Tiqr. This secret may only be used for the AE of the trusted device cookies.
     #   The secret key size is fixed, it must be 256 bits (32 bytes (64 hex digits))

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,6 +21,7 @@ services:
             $appSecret: '%app_secret%'
             $sessionOptions: '%session.storage.options%'
             $correlationIdSalt: '%correlation_id_salt%'
+            $trustedDeviceCookieEnforcementEnabled: '%trusted_device_enforcement_enabled%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Service/TrustedDeviceHelper.php
+++ b/src/Service/TrustedDeviceHelper.php
@@ -31,6 +31,7 @@ readonly class TrustedDeviceHelper
     public function __construct(
         private TrustedDeviceService $cookieService,
         private LoggerInterface $logger,
+        private bool $trustedDeviceCookieEnforcementEnabled,
     ) {
     }
 
@@ -50,5 +51,10 @@ readonly class TrustedDeviceHelper
         } catch (Throwable $e) {
             $this->logger->warning('Could not register trusted device on registration', ['exception' => $e]);
         }
+    }
+
+    public function trustedDeviceCookieEnforcementEnabled(): bool
+    {
+        return $this->trustedDeviceCookieEnforcementEnabled === true;
     }
 }

--- a/tests/Unit/Controller/AuthenticationNotificationControllerTest.php
+++ b/tests/Unit/Controller/AuthenticationNotificationControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright 2025 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Surfnet\GsspBundle\Service\AuthenticationService;
+use Surfnet\GsspBundle\Service\StateHandlerInterface;
+use Surfnet\Tiqr\Controller\AuthenticationNotificationController;
+use Surfnet\Tiqr\Service\TrustedDevice\TrustedDeviceService;
+use Surfnet\Tiqr\Service\TrustedDeviceHelper;
+use Surfnet\Tiqr\Tiqr\Legacy\TiqrUser;
+use Surfnet\Tiqr\Tiqr\TiqrServiceInterface;
+use Surfnet\Tiqr\Tiqr\TiqrUserRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class AuthenticationNotificationControllerTest extends TestCase
+{
+    private AuthenticationService $authService;
+    private StateHandlerInterface $stateHandler;
+    private TiqrServiceInterface $tiqrService;
+    private TiqrUserRepositoryInterface $userRepository;
+    private TrustedDeviceService $trustedDeviceService;
+
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        $this->authService = $this->createMock(AuthenticationService::class);
+        $this->stateHandler = $this->createMock(StateHandlerInterface::class);
+        $this->tiqrService = $this->createMock(TiqrServiceInterface::class);
+        $this->userRepository = $this->createMock(TiqrUserRepositoryInterface::class);
+        $this->trustedDeviceService = $this->createMock(TrustedDeviceService::class);
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    public function provideTrustedDeviceCookieEnforcementEnabledScenarios(): array
+    {
+        return [
+          [false, '"success"'],
+          [true, '"no-trusted-device"'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTrustedDeviceCookieEnforcementEnabledScenarios
+     */
+    public function testTrustedDeviceCookieEnforcement(bool $trustedDeviceCookieEnforcementEnabled, string $expectedResponse): void
+    {
+        $controller = $this->makeController($trustedDeviceCookieEnforcementEnabled);
+        $this->authService->method('authenticationRequired')->willReturn(true);
+
+        $user = $this->mockUser('ACN', '01011001');
+
+        $this->userRepository->method('getUser')->willReturn($user);
+        $this->trustedDeviceService->method('read')->willReturn(null);
+
+        $request = $this->createMock(Request::class);
+
+        $response = $controller->__invoke($request);
+
+        $this->assertSame($expectedResponse, $response->getContent());
+    }
+
+    private function makeController(bool $trustedDeviceCookieEnforcementEnabled): AuthenticationNotificationController
+    {
+        return new AuthenticationNotificationController(
+            $this->authService,
+            $this->stateHandler,
+            $this->tiqrService,
+            $this->userRepository,
+            new NullLogger(),
+            $this->trustedDeviceService,
+            new TrustedDeviceHelper($this->trustedDeviceService, new NullLogger(), $trustedDeviceCookieEnforcementEnabled),
+        );
+    }
+
+    private function mockUser(string $notificationType, string $notificationAddress): TiqrUser
+    {
+        $user = $this->createMock(TiqrUser::class);
+        $user->expects($this->once())->method('getNotificationType')->willReturn($notificationType);
+        $user->method('getNotificationAddress')->willReturn($notificationAddress);
+        return $user;
+    }
+}


### PR DESCRIPTION
Prior to this change, it was not possible to do a 'warm' rollout of the notification fatique attack prevention feature.

This change makes this possible by disabling the enforcement of the check.

Fixes https://github.com/OpenConext/Stepup-tiqr/issues/343